### PR TITLE
Updates generated code template to conform with rust 1.53 lints

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -333,8 +333,8 @@ mod tests {
 "#;
 
         let expected = "
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct Test {
     pub a: i64,
     pub b: String,
@@ -375,8 +375,8 @@ impl Default for Test {
 
         let expected = r#"
 /// Hi there.
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct User {
     pub name: String,
     pub favorite_number: i32,
@@ -454,8 +454,8 @@ impl Default for User {
 "#;
 
         let expected = r#"
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct Variable {
     pub oid: Option<Vec<i64>>,
     pub val: Option<String>,
@@ -470,8 +470,8 @@ impl Default for Variable {
     }
 }
 
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct TrapV1 {
     pub var: Option<Vec<Variable>>,
 }
@@ -484,8 +484,8 @@ impl Default for TrapV1 {
     }
 }
 
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct V1 {
     pub pdu: Option<TrapV1>,
 }
@@ -498,8 +498,8 @@ impl Default for V1 {
     }
 }
 
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct Snmp {
     pub v1: Option<V1>,
 }
@@ -547,8 +547,8 @@ impl Default for Snmp {
 "#;
 
         let expected = r#"
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct KsqlDataSourceSchema {
     #[serde(rename = "ID")]
     pub id: Option<String>,
@@ -598,8 +598,8 @@ pub enum UnionStringLongDoubleBoolean {
     Boolean(bool),
 }
 
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct Contact {
     pub extra: ::std::collections::HashMap<String, Option<UnionStringLongDoubleBoolean>>,
 }
@@ -639,8 +639,8 @@ impl Default for Contact {
 "#;
 
         let expected = r#"
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct AvroShortUuid {
     #[serde(rename = "mostBits")]
     pub most_bits: i64,
@@ -664,8 +664,8 @@ pub enum UnionStringAvroShortUuid {
     AvroShortUuid(AvroShortUuid),
 }
 
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct AvroFileId {
     pub id: UnionStringAvroShortUuid,
 }
@@ -708,8 +708,8 @@ pub enum UnionStringLongDoubleBoolean {
     Boolean(bool),
 }
 
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct Contact {
     pub extra: ::std::collections::HashMap<String, Option<UnionStringLongDoubleBoolean>>,
 }
@@ -752,8 +752,8 @@ impl Default for Contact {
 "#;
 
         let expected = r#"
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct AvroShortUuid {
     #[serde(rename = "mostBits")]
     pub most_bits: i64,
@@ -777,8 +777,8 @@ pub enum UnionStringAvroShortUuid {
     AvroShortUuid(AvroShortUuid),
 }
 
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct AvroFileId {
     pub id: UnionStringAvroShortUuid,
 }
@@ -826,8 +826,8 @@ macro_rules! deser(
     );
 );
 
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct Test {
     #[serde(deserialize_with = "nullable_test_a")]
     pub a: i64,
@@ -868,8 +868,8 @@ impl Default for Test {
             );
         );
 
-        #[serde(default)]
         #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[serde(default)]
         pub struct Test {
             #[serde(deserialize_with = "nullable_test_a")]
             pub a: i64,
@@ -964,8 +964,8 @@ impl Default for Test {
         schema_b_file.write_all(schema_b_str.as_bytes())?;
 
         let expected = r#"
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct B {
     pub field_one: A,
 }
@@ -978,8 +978,8 @@ impl Default for B {
     }
 }
 
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct A {
     pub field_one: f32,
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -31,8 +31,8 @@ pub const RECORD_TEMPLATE: &str = r#"
 {%- if doc %}
 /// {{ doc }}
 {%- endif %}
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct {{ name }} {
     {%- for f in fields %}
     {%- set type = types[f] %}
@@ -1223,8 +1223,8 @@ mod tests {
 "#;
 
         let expected = r#"
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct User {
     pub r#as: String,
     #[serde(rename = "favoriteNumber")]
@@ -1277,8 +1277,8 @@ impl Default for User {
 "#;
 
         let expected = r#"
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct User {
     #[serde(rename = "m-f64")]
     pub m_f64: ::std::collections::HashMap<String, f64>,
@@ -1323,8 +1323,8 @@ impl Default for User {
 "#;
 
         let expected = r#"
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct User {
     pub info: Info,
 }
@@ -1417,8 +1417,8 @@ pub type Md5 = [u8; 16];
         let res = templater.str_record(&schema, &gs).unwrap();
 
         let expected = "
-#[serde(default)]
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct Contact {
     pub extra: Option<UnionStringLongDoubleBoolean>,
 }


### PR DESCRIPTION
This fixes a built-in lint issue when the `serde(default)` helper is used before it is introduced by `derive(serde::*)` in the generated code. This will become a hard error in the future.
See <https://github.com/rust-lang/rust/issues/79202>
<https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint_defs/builtin/static.LEGACY_DERIVE_HELPERS.html>