### PR TITLE
Add option to derive builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Options:
   --precision=P     Precision for f32/f64 default values that aren't round numbers [default: 3].
   --variant-access  Derive the traits in the variant_access_traits crate on union types.
   --union-deser     Custom deserialization for avro-rs multi-valued union types.
+  --derive-builders Derive builders for generated record structs.
   -V, --version     Show version.
   -h, --help        Show this screen.
 ```
@@ -97,6 +98,9 @@ Note also that the `Generator` can be customized with a builder:
 let g = Generator::builder().precision(2).build().unwrap();
 ```
 
+The `derive_builders` option will use the [derive-builder][] crate to derive builders for the generated structs.
+The builders will only be derived for those structs that are generated from Avro records.
+
 ## Limitations
 
 * Avro schema `namespace` fields are ignored, therefore names from a single schema must
@@ -105,3 +109,4 @@ let g = Generator::builder().precision(2).build().unwrap();
 [schemas]: https://avro.apache.org/docs/current/spec.html
 [avro-rs]: https://github.com/flavray/avro-rs
 [serde]: https://serde.rs
+[derive-builder]: https://github.com/colin-kiegel/rust-derive-builder

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -260,6 +260,7 @@ pub struct GeneratorBuilder {
     nullable: bool,
     use_variant_access: bool,
     use_avro_rs_unions: bool,
+    derive_builders: bool,
 }
 
 impl GeneratorBuilder {
@@ -270,6 +271,7 @@ impl GeneratorBuilder {
             nullable: false,
             use_variant_access: false,
             use_avro_rs_unions: false,
+            derive_builders: false,
         }
     }
 
@@ -300,6 +302,13 @@ impl GeneratorBuilder {
         self
     }
 
+    /// Adds support to derive builders using the `rust-derive-builder` crate.
+    /// Will derive builders for record structs.
+    pub fn derive_builders(mut self, derive_builders: bool) -> GeneratorBuilder {
+        self.derive_builders = derive_builders;
+        self
+    }
+
     /// Create a `Generator` with the builder parameters.
     pub fn build(self) -> Result<Generator> {
         let mut templater = Templater::new()?;
@@ -307,6 +316,7 @@ impl GeneratorBuilder {
         templater.nullable = self.nullable;
         templater.use_variant_access = self.use_variant_access;
         templater.use_avro_rs_unions = self.use_avro_rs_unions;
+        templater.derive_builders = self.derive_builders;
         Ok(Generator { templater })
     }
 }

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -376,6 +376,45 @@ impl Default for Test {
     }
 
     #[test]
+    fn simple_with_builders() {
+        let raw_schema = r#"
+{
+  "type": "record",
+  "name": "test",
+  "fields": [
+    {"name": "a", "type": "long", "default": 42},
+    {"name": "b", "type": "string"}
+  ]
+}
+"#;
+
+        let expected = "
+#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize, derive_builder::Builder)]
+#[serde(default)]
+#[builder(setter(into))]
+pub struct Test {
+    pub a: i64,
+    pub b: String,
+}
+
+impl Default for Test {
+    fn default() -> Test {
+        Test {
+            a: 42,
+            b: String::default(),
+        }
+    }
+}
+";
+
+        let g = GeneratorBuilder::new()
+            .derive_builders(true)
+            .build()
+            .unwrap();
+        assert_schema_gen!(g, expected, raw_schema);
+    }
+
+    #[test]
     fn complex() {
         let raw_schema = r#"
 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ Options:
   --precision=P     Precision for f32/f64 default values that aren't round numbers [default: 3].
   --variant-access  Derive the traits in the variant_access_traits crate on union types.
   --union-deser     Custom deserialization for avro-rs multi-valued union types.
+  --derive-builders Derive builders for generated record structs.
   -V, --version     Show version.
   -h, --help        Show this screen.
 ";
@@ -34,6 +35,7 @@ struct CmdArgs {
     flag_precision: Option<usize>,
     flag_variant_access: bool,
     flag_union_deser: bool,
+    flag_derive_builders: bool,
     flag_version: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,14 +16,14 @@ Usage:
   rsgen-avro (-V | --version)
 
 Options:
-  --fmt             Run rustfmt on the resulting <output-file>
-  --nullable        Replace null fields with their default value when deserializing.
-  --precision=P     Precision for f32/f64 default values that aren't round numbers [default: 3].
-  --variant-access  Derive the traits in the variant_access_traits crate on union types.
-  --union-deser     Custom deserialization for avro-rs multi-valued union types.
-  --derive-builders Derive builders for generated record structs.
-  -V, --version     Show version.
-  -h, --help        Show this screen.
+  --fmt              Run rustfmt on the resulting <output-file>
+  --nullable         Replace null fields with their default value when deserializing.
+  --precision=P      Precision for f32/f64 default values that aren't round numbers [default: 3].
+  --variant-access   Derive the traits in the variant_access_traits crate on union types.
+  --union-deser      Custom deserialization for avro-rs multi-valued union types.
+  --derive-builders  Derive builders for generated record structs.
+  -V, --version      Show version.
+  -h, --help         Show this screen.
 ";
 
 #[derive(Debug, Deserialize)]
@@ -66,6 +66,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         .nullable(args.flag_nullable)
         .use_variant_access(args.flag_variant_access)
         .use_avro_rs_unions(args.flag_union_deser)
+        .derive_builders(args.flag_derive_builders)
         .build()?;
 
     g.gen(&source, &mut out)?;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -31,8 +31,11 @@ pub const RECORD_TEMPLATE: &str = r#"
 {%- if doc %}
 /// {{ doc }}
 {%- endif %}
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize{%- if derive_builders %}, derive_builder::Builder {%- endif %})]
 #[serde(default)]
+{%- if derive_builders %}
+#[builder(setter(into))]
+{%- endif %}
 pub struct {{ name }} {
     {%- for f in fields %}
     {%- set type = types[f] %}
@@ -199,6 +202,7 @@ pub struct Templater {
     pub nullable: bool,
     pub use_variant_access: bool,
     pub use_avro_rs_unions: bool,
+    pub derive_builders: bool,
 }
 
 impl Templater {
@@ -217,6 +221,7 @@ impl Templater {
             nullable: false,
             use_variant_access: false,
             use_avro_rs_unions: false,
+            derive_builders: false,
         })
     }
 
@@ -282,6 +287,7 @@ impl Templater {
             ctx.insert("name", &name.to_camel_case());
             let doc = if let Some(d) = doc { d } else { "" };
             ctx.insert("doc", doc);
+            ctx.insert("derive_builders", &self.derive_builders);
 
             let mut f = Vec::new(); // field names;
             let mut t = HashMap::new(); // field name -> field type


### PR DESCRIPTION
Uses the `derive_builder` crate to derive Builders for structs generated
from Avro record schemas.

resolves #20 