### PR TITLE
Multiline doc comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "memchr",
 ]
@@ -113,19 +113,31 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120"
+checksum = "58549f1842da3080ce63002102d5bc954c7bc843d4f47818e642abdc36253552"
 dependencies = [
  "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db058d493fb2f65f41861bfed7e3fe6335264a9f0f92710cab5bdf01fef09069"
+dependencies = [
  "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
 dependencies = [
  "cfg-if",
 ]
@@ -161,7 +173,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -199,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -269,6 +281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "humansize"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "lazy_static"
@@ -306,9 +324,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libflate"
@@ -383,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "opaque-debug"
@@ -452,25 +470,64 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.10"
+name = "phf"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.4",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+ "uncased",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -604,7 +661,7 @@ dependencies = [
  "avro-rs",
  "docopt",
  "glob",
- "heck",
+ "heck 0.4.0",
  "lazy_static",
  "serde",
  "serde_json",
@@ -616,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "same-file"
@@ -631,18 +688,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -651,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
  "itoa",
  "ryu",
@@ -671,6 +728,12 @@ dependencies = [
  "fake-simd",
  "opaque-debug",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
 
 [[package]]
 name = "slug"
@@ -699,7 +762,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -707,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -718,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -744,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.12.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95b0d8a46da5fe3ea119394a6c7f1e745f9de359081641c99946e2bf55d4f2"
+checksum = "d3cac831b615c25bcef632d1cabf864fa05813baad3d526829db18eb70e8b58d"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -766,18 +829,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -806,15 +869,24 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "uncased"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baeed7327e25054889b9bd4f975f32e5f4c5d434042d59ab6cd4142c0a76ed0"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -890,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rsgen-avro"
 version = "0.9.8"
 authors = ["Romain Leroux <romain@leroux.dev>"]
-edition = "2018"
+edition = "2021"
 description = "Command line and library for generating Rust types from Avro schemas"
 keywords = ["avro", "code-generation", "serde"]
 repository = "https://github.com/lerouxrgd/rsgen-avro"
@@ -13,7 +13,7 @@ readme = "README.md"
 avro-rs = "0.13"
 docopt = "1"
 glob = "0.3"
-heck = "0.3"
+heck = "0.4"
 lazy_static = "1"
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -48,7 +48,7 @@ impl Generator {
             }
 
             Source::SchemaStr(raw_schema) => {
-                let schema = Schema::parse_str(&raw_schema)?;
+                let schema = Schema::parse_str(raw_schema)?;
                 let mut deps = deps_stack(&schema, vec![]);
                 self.gen_in_order(&mut deps, output)?;
             }
@@ -63,10 +63,10 @@ impl Generator {
                 }
 
                 let schemas = &raw_schemas.iter().map(|s| s.as_str()).collect::<Vec<_>>();
-                let schemas = Schema::parse_list(&schemas)?;
+                let schemas = Schema::parse_list(schemas)?;
                 let mut deps = schemas
                     .iter()
-                    .fold(vec![], |deps, schema| deps_stack(&schema, deps));
+                    .fold(vec![], |deps, schema| deps_stack(schema, deps));
 
                 self.gen_in_order(&mut deps, output)?;
             }
@@ -125,7 +125,7 @@ impl Generator {
                     gs.put_type(&s, type_str)
                 }
 
-                _ => Err(Error::Schema(format!("Not a valid root schema: {:?}", s)))?,
+                _ => return Err(Error::Schema(format!("Not a valid root schema: {:?}", s))),
             }
         }
 
@@ -263,16 +263,22 @@ pub struct GeneratorBuilder {
     derive_builders: bool,
 }
 
-impl GeneratorBuilder {
-    /// Creates a new `GeneratorBuilder`.
-    pub fn new() -> GeneratorBuilder {
-        GeneratorBuilder {
+impl Default for GeneratorBuilder {
+    fn default() -> Self {
+        Self {
             precision: 3,
             nullable: false,
             use_variant_access: false,
             use_avro_rs_unions: false,
             derive_builders: false,
         }
+    }
+}
+
+impl GeneratorBuilder {
+    /// Creates a new `GeneratorBuilder`.
+    pub fn new() -> GeneratorBuilder {
+        GeneratorBuilder::default()
     }
 
     /// Sets the precision for default values of f32/f64 fields.
@@ -1156,7 +1162,7 @@ impl Default for Test {
 }
 "#;
 
-        let schema = Schema::parse_str(&raw_schema).unwrap();
+        let schema = Schema::parse_str(raw_schema).unwrap();
         let mut deps = deps_stack(&schema, vec![]);
 
         let s = deps.pop().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@ use docopt::Docopt;
 use rsgen_avro::{Generator, Source};
 use serde::Deserialize;
 
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-const USAGE: &'static str = "
+const USAGE: &str = "
 Usage:
   rsgen-avro [options] <schema-file-pattern> <output-file>
   rsgen-avro (-h | --help)

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,5 +1,7 @@
 //! Logic for templating Rust types and default values from Avro schema.
 
+#![allow(clippy::try_err)]
+
 use std::collections::{HashMap, HashSet};
 
 use avro_rs::schema::{Name, RecordField, UnionSchema};
@@ -256,7 +258,7 @@ impl Templater {
             ..
         } = schema
         {
-            if symbols.len() == 0 {
+            if symbols.is_empty() {
                 err!("No symbol for emum: {:?}", name)?
             }
             let mut ctx = Context::new();
@@ -659,7 +661,7 @@ impl Templater {
                 Some(Value::String(s)) => {
                     format!(
                         r#"uuid::Uuid::parse_str("{}").unwrap()"#,
-                        Uuid::parse_str(&s)?.to_string()
+                        Uuid::parse_str(s)?
                     )
                 }
                 None => "uuid::Uuid::nil()".to_string(),
@@ -674,7 +676,7 @@ impl Templater {
                     }
                     format!("{:?}", bytes)
                 }
-                None => String::from_utf8_lossy(&vec![0; 12]).to_string(),
+                None => String::from_utf8_lossy(&[0; 12]).to_string(),
                 _ => err!("Invalid default: {:?}", default)?,
             },
 
@@ -835,7 +837,7 @@ impl Templater {
                 ..
             } => {
                 let default_str = if let Some(Value::Object(o)) = default {
-                    if o.len() > 0 {
+                    if !o.is_empty() {
                         let vals = o
                             .iter()
                             .map(|(k, v)| {
@@ -1047,14 +1049,14 @@ pub(crate) fn union_type(
 ) -> Result<String> {
     let variants = union.variants();
 
-    if variants.len() == 0 {
+    if variants.is_empty() {
         err!("Invalid empty Schema::Union")?
     } else if variants.len() == 1 && variants[0] == Schema::Null {
         err!("Invalid Schema::Union of only Schema::Null")?
     }
 
     if union.is_nullable() && variants.len() == 2 {
-        return Ok(option_type(&variants[1], gen_state)?);
+        return option_type(&variants[1], gen_state);
     }
 
     let schemas = if variants[0] == Schema::Null {
@@ -1071,7 +1073,7 @@ pub(crate) fn union_type(
     if variants[0] == Schema::Null && wrap_if_optional {
         Ok(format!("Option<{}>", type_str))
     } else {
-        Ok(type_str.into())
+        Ok(type_str)
     }
 }
 
@@ -1183,7 +1185,7 @@ impl Default for User {
 "#;
 
         let templater = Templater::new().unwrap();
-        let schema = Schema::parse_str(&raw_schema).unwrap();
+        let schema = Schema::parse_str(raw_schema).unwrap();
         let gs = GenState::new();
         let res = templater.str_record(&schema, &gs).unwrap();
 
@@ -1222,7 +1224,7 @@ impl Default for User {
 "#;
 
         let templater = Templater::new().unwrap();
-        let schema = Schema::parse_str(&raw_schema).unwrap();
+        let schema = Schema::parse_str(raw_schema).unwrap();
         let gs = GenState::new();
         let res = templater.str_record(&schema, &gs).unwrap();
 
@@ -1267,7 +1269,7 @@ impl Default for User {
 "#;
 
         let templater = Templater::new().unwrap();
-        let schema = Schema::parse_str(&raw_schema).unwrap();
+        let schema = Schema::parse_str(raw_schema).unwrap();
         let gs = GenState::new();
         let res = templater.str_record(&schema, &gs).unwrap();
 
@@ -1286,7 +1288,7 @@ impl Default for User {
 "#;
 
         let templater = Templater::new().unwrap();
-        let schema = Schema::parse_str(&raw_schema).unwrap();
+        let schema = Schema::parse_str(raw_schema).unwrap();
         let res = templater.str_enum(&schema).unwrap();
 
         let expected = r#"
@@ -1316,7 +1318,7 @@ pub enum Colors {
 "#;
 
         let templater = Templater::new().unwrap();
-        let schema = Schema::parse_str(&raw_schema).unwrap();
+        let schema = Schema::parse_str(raw_schema).unwrap();
         let res = templater.str_fixed(&schema).unwrap();
 
         let expected = "
@@ -1340,7 +1342,7 @@ pub type Md5 = [u8; 16];
 "#;
 
         let templater = Templater::new().unwrap();
-        let schema = Schema::parse_str(&raw_schema).unwrap();
+        let schema = Schema::parse_str(raw_schema).unwrap();
         let gs = GenState::new();
         let res = templater.str_record(&schema, &gs).unwrap();
 
@@ -1375,7 +1377,7 @@ impl Default for Contact {
 "#;
 
         let templater = Templater::new().unwrap();
-        let schema = Schema::parse_str(&raw_schema).unwrap();
+        let schema = Schema::parse_str(raw_schema).unwrap();
         let res = templater.str_enum(&schema).unwrap();
 
         let expected = r#"
@@ -1423,7 +1425,7 @@ impl Default for User {
 "#;
 
         let templater = Templater::new().unwrap();
-        let schema = Schema::parse_str(&raw_schema).unwrap();
+        let schema = Schema::parse_str(raw_schema).unwrap();
         let gs = GenState::new();
         let res = templater.str_record(&schema, &gs).unwrap();
 

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 
 use avro_rs::schema::{Name, RecordField, UnionSchema};
 use avro_rs::Schema;
-use heck::{CamelCase, SnakeCase};
+use heck::{ToSnakeCase, ToUpperCamelCase};
 use lazy_static::lazy_static;
 use serde_json::Value;
 use tera::{Context, Tera};
@@ -241,7 +241,7 @@ impl Templater {
         } = schema
         {
             let mut ctx = Context::new();
-            ctx.insert("name", &sanitize(name.to_camel_case()));
+            ctx.insert("name", &sanitize(name.to_upper_camel_case()));
             ctx.insert("size", size);
             Ok(self.tera.render(FIXED_TERA, &ctx)?)
         } else {
@@ -262,16 +262,16 @@ impl Templater {
                 err!("No symbol for emum: {:?}", name)?
             }
             let mut ctx = Context::new();
-            ctx.insert("name", &sanitize(name.to_camel_case()));
+            ctx.insert("name", &sanitize(name.to_upper_camel_case()));
             let doc = if let Some(d) = doc { d } else { "" };
             ctx.insert("doc", doc);
             let o: HashMap<_, _> = symbols
                 .iter()
-                .map(|s| (sanitize(s.to_camel_case()), s))
+                .map(|s| (sanitize(s.to_upper_camel_case()), s))
                 .collect();
             let s: Vec<_> = symbols
                 .iter()
-                .map(|s| sanitize(s.to_camel_case()))
+                .map(|s| sanitize(s.to_upper_camel_case()))
                 .collect();
             ctx.insert("originals", &o);
             ctx.insert("symbols", &s);
@@ -292,7 +292,7 @@ impl Templater {
         } = schema
         {
             let mut ctx = Context::new();
-            ctx.insert("name", &name.to_camel_case());
+            ctx.insert("name", &name.to_upper_camel_case());
             let doc = if let Some(d) = doc { d } else { "" };
             ctx.insert("doc", doc);
             ctx.insert("derive_builders", &self.derive_builders);
@@ -394,7 +394,7 @@ impl Templater {
                         ..
                     } => {
                         let default = self.parse_default(schema, gen_state, default.as_ref())?;
-                        let f_name = sanitize(f_name.to_camel_case());
+                        let f_name = sanitize(f_name.to_upper_camel_case());
                         f.push(name_std.clone());
                         t.insert(name_std.clone(), f_name.clone());
                         d.insert(name_std.clone(), default);
@@ -429,7 +429,7 @@ impl Templater {
                         ..
                     } => {
                         let default = self.parse_default(schema, gen_state, default.as_ref())?;
-                        let r_name = sanitize(r_name.to_camel_case());
+                        let r_name = sanitize(r_name.to_upper_camel_case());
                         f.push(name_std.clone());
                         t.insert(name_std.clone(), r_name.clone());
                         d.insert(name_std.clone(), default);
@@ -440,7 +440,7 @@ impl Templater {
                         ..
                     } => {
                         let default = self.parse_default(schema, gen_state, default.as_ref())?;
-                        let e_name = sanitize(e_name.to_camel_case());
+                        let e_name = sanitize(e_name.to_upper_camel_case());
                         f.push(name_std.clone());
                         t.insert(name_std.clone(), e_name);
                         d.insert(name_std.clone(), default);
@@ -522,19 +522,19 @@ impl Templater {
                         name: Name { name, .. },
                         ..
                     } => {
-                        format!("{rec}({rec})", rec = name.to_camel_case())
+                        format!("{rec}({rec})", rec = name.to_upper_camel_case())
                     }
                     Schema::Enum {
                         name: Name { name, .. },
                         ..
                     } => {
-                        format!("{e}({e})", e = sanitize(name.to_camel_case()))
+                        format!("{e}({e})", e = sanitize(name.to_upper_camel_case()))
                     }
                     Schema::Fixed {
                         name: Name { name, .. },
                         ..
                     } => {
-                        format!("{f}({f})", f = sanitize(name.to_camel_case()))
+                        format!("{f}({f})", f = sanitize(name.to_upper_camel_case()))
                     }
                     Schema::Decimal { .. } => "Decimal(avro_rs::Decimal)".into(),
                     Schema::Uuid => "Uuid(uuid::Uuid)".into(),
@@ -738,22 +738,22 @@ impl Templater {
                 symbols,
                 ..
             } => {
-                let e_name = sanitize(e_name.to_camel_case());
+                let e_name = sanitize(e_name.to_upper_camel_case());
                 let valids: HashSet<_> = symbols
                     .iter()
-                    .map(|s| sanitize(s.to_camel_case()))
+                    .map(|s| sanitize(s.to_upper_camel_case()))
                     .collect();
                 match default {
                     Some(Value::String(ref s)) => {
-                        let s = sanitize(s.to_camel_case());
+                        let s = sanitize(s.to_upper_camel_case());
                         if valids.contains(&s) {
-                            format!("{}::{}", e_name, sanitize(s.to_camel_case()))
+                            format!("{}::{}", e_name, sanitize(s.to_upper_camel_case()))
                         } else {
                             err!("Invalid default: {:?}", default)?
                         }
                     }
                     None if !symbols.is_empty() => {
-                        format!("{}::{}", e_name, sanitize(symbols[0].to_camel_case()))
+                        format!("{}::{}", e_name, sanitize(symbols[0].to_upper_camel_case()))
                     }
                     _ => err!("Invalid default: {:?}", default)?,
                 }
@@ -853,14 +853,14 @@ impl Templater {
                             .join(" ");
                         format!(
                             "{{ let mut r = {}::default(); {} r }}",
-                            sanitize(name.to_camel_case()),
+                            sanitize(name.to_upper_camel_case()),
                             vals
                         )
                     } else {
-                        format!("{}::default()", sanitize(name.to_camel_case()))
+                        format!("{}::default()", sanitize(name.to_upper_camel_case()))
                     }
                 } else {
-                    format!("{}::default()", sanitize(name.to_camel_case()))
+                    format!("{}::default()", sanitize(name.to_upper_camel_case()))
                 };
                 Ok(default_str)
             }
@@ -916,7 +916,7 @@ pub(crate) fn array_type(inner: &Schema, gen_state: &GenState) -> Result<String>
             name: Name { name: f_name, .. },
             ..
         } => {
-            let f_name = sanitize(f_name.to_camel_case());
+            let f_name = sanitize(f_name.to_upper_camel_case());
             format!("Vec<{}>", f_name)
         }
 
@@ -937,7 +937,7 @@ pub(crate) fn array_type(inner: &Schema, gen_state: &GenState) -> Result<String>
         | Schema::Enum {
             name: Name { name, .. },
             ..
-        } => format!("Vec<{}>", &sanitize(name.to_camel_case())),
+        } => format!("Vec<{}>", &sanitize(name.to_upper_camel_case())),
 
         Schema::Null => err!("Invalid use of Schema::Null")?,
     };
@@ -973,7 +973,7 @@ pub(crate) fn map_type(inner: &Schema, gen_state: &GenState) -> Result<String> {
             name: Name { name: f_name, .. },
             ..
         } => {
-            let f_name = sanitize(f_name.to_camel_case());
+            let f_name = sanitize(f_name.to_upper_camel_case());
             map_of(&f_name)
         }
 
@@ -994,7 +994,7 @@ pub(crate) fn map_type(inner: &Schema, gen_state: &GenState) -> Result<String> {
         | Schema::Enum {
             name: Name { name, .. },
             ..
-        } => map_of(&sanitize(name.to_camel_case())),
+        } => map_of(&sanitize(name.to_upper_camel_case())),
 
         Schema::Null => err!("Invalid use of Schema::Null")?,
     };
@@ -1016,15 +1016,15 @@ fn union_enum_variant(schema: &Schema, gen_state: &GenState) -> Result<String> {
         Schema::Record {
             name: Name { name, .. },
             ..
-        } => name.to_camel_case(),
+        } => name.to_upper_camel_case(),
         Schema::Enum {
             name: Name { name, .. },
             ..
-        } => sanitize(name.to_camel_case()),
+        } => sanitize(name.to_upper_camel_case()),
         Schema::Fixed {
             name: Name { name, .. },
             ..
-        } => sanitize(name.to_camel_case()),
+        } => sanitize(name.to_upper_camel_case()),
 
         Schema::Decimal { .. } => "Decimal".into(),
         Schema::Uuid => "Uuid".into(),
@@ -1102,7 +1102,7 @@ pub(crate) fn option_type(inner: &Schema, gen_state: &GenState) -> Result<String
             name: Name { name: f_name, .. },
             ..
         } => {
-            let f_name = sanitize(f_name.to_camel_case());
+            let f_name = sanitize(f_name.to_upper_camel_case());
             format!("Option<{}>", f_name)
         }
 
@@ -1123,7 +1123,7 @@ pub(crate) fn option_type(inner: &Schema, gen_state: &GenState) -> Result<String
         | Schema::Enum {
             name: Name { name, .. },
             ..
-        } => format!("Option<{}>", &sanitize(name.to_camel_case())),
+        } => format!("Option<{}>", &sanitize(name.to_upper_camel_case())),
 
         Schema::Null => err!("Invalid use of Schema::Null")?,
     };


### PR DESCRIPTION
- Add support for `doc` fields that contain `\n`, a.k.a. multiline comments
- Fix Clippy lint warnings
- Update rust edition to 2021
- Update heck to 0.4 