### PR TITLE
Fix clippy errors in generated files on 1.63 rust

### DIFF
--- a/tests/generation.rs
+++ b/tests/generation.rs
@@ -129,3 +129,8 @@ fn gen_enums_multiline_doc() {
 fn gen_fixed() {
     validate_generation("fixed", Generator::new().unwrap());
 }
+
+#[test]
+fn nested_with_float() {
+    validate_generation("nested_with_float", Generator::new().unwrap());
+}

--- a/tests/schemas/mod.rs
+++ b/tests/schemas/mod.rs
@@ -19,3 +19,4 @@ pub mod record_multiline_doc;
 pub mod simple;
 pub mod simple_with_builders;
 pub mod simple_with_schemas;
+pub mod nested_with_float;

--- a/tests/schemas/multi_valued_union_records.avsc
+++ b/tests/schemas/multi_valued_union_records.avsc
@@ -14,7 +14,7 @@
     }, {
       "type": "record",
       "name": "Baz",
-      "fields": [ {"name": "d", "type": "int"} ]
+      "fields": [ {"name": "d", "type": "float"} ]
     } ]
   } ]
 }

--- a/tests/schemas/multi_valued_union_records.rs
+++ b/tests/schemas/multi_valued_union_records.rs
@@ -1,10 +1,10 @@
 
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Baz {
-    pub d: i32,
+    pub d: f32,
 }
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Bar {
     pub c: i64,
 }

--- a/tests/schemas/nested_record_default.rs
+++ b/tests/schemas/nested_record_default.rs
@@ -1,10 +1,10 @@
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Inner {
     pub a: bool,
 }
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct User {
     #[serde(rename = "m-f64")]

--- a/tests/schemas/nested_record_partial_default.rs
+++ b/tests/schemas/nested_record_partial_default.rs
@@ -1,5 +1,5 @@
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Nested {
     pub a: i32,
     #[serde(default = "default_nested_b")]
@@ -9,7 +9,7 @@ pub struct Nested {
 #[inline(always)]
 fn default_nested_b() -> i32 { 20 }
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct User {
     pub nested: Nested,

--- a/tests/schemas/nested_with_float.avsc
+++ b/tests/schemas/nested_with_float.avsc
@@ -1,0 +1,29 @@
+{
+  "type": "record",
+  "name": "Foo",
+  "fields": [ {
+      "name": "Bar",
+      "type": "record",
+      "fields": [ {
+          "name": "Baz",
+          "type": "record",
+          "fields": [ {
+              "name": "FooFoo",
+              "type": "record",
+              "fields": [ {"name": "test_map", "type": "map", "values": "float"} ]
+            }, {
+              "name": "FooBar",
+              "type": "record",
+              "fields": [
+                {"name": "test_vec", "type": "array", "items": "float"},
+                {"name": "float_union", "type": ["float", "int"]},
+                {"name": "int_union", "type": ["int", "long"]}
+              ]
+          } ]
+        } ]
+    }, {
+      "name": "FooBaz",
+      "type": "record",
+      "fields": [ {"name": "BarFoo",  "type": "record", "fields": [ {"name": "nested_int", "type": "int"} ]} ]
+    }
+] }

--- a/tests/schemas/nested_with_float.rs
+++ b/tests/schemas/nested_with_float.rs
@@ -1,0 +1,131 @@
+
+/// Auto-generated type for unnamed Avro union variants.
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+pub enum UnionIntLong {
+    Int(i32),
+    Long(i64),
+}
+
+impl From<i32> for UnionIntLong {
+    fn from(v: i32) -> Self {
+        Self::Int(v)
+    }
+}
+
+impl TryFrom<UnionIntLong> for i32 {
+    type Error = UnionIntLong;
+
+    fn try_from(v: UnionIntLong) -> Result<Self, Self::Error> {
+        if let UnionIntLong::Int(v) = v {
+            Ok(v)
+        } else {
+            Err(v)
+        }
+    }
+}
+
+impl From<i64> for UnionIntLong {
+    fn from(v: i64) -> Self {
+        Self::Long(v)
+    }
+}
+
+impl TryFrom<UnionIntLong> for i64 {
+    type Error = UnionIntLong;
+
+    fn try_from(v: UnionIntLong) -> Result<Self, Self::Error> {
+        if let UnionIntLong::Long(v) = v {
+            Ok(v)
+        } else {
+            Err(v)
+        }
+    }
+}
+
+/// Auto-generated type for unnamed Avro union variants.
+#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+pub enum UnionFloatInt {
+    Float(f32),
+    Int(i32),
+}
+
+impl From<f32> for UnionFloatInt {
+    fn from(v: f32) -> Self {
+        Self::Float(v)
+    }
+}
+
+impl TryFrom<UnionFloatInt> for f32 {
+    type Error = UnionFloatInt;
+
+    fn try_from(v: UnionFloatInt) -> Result<Self, Self::Error> {
+        if let UnionFloatInt::Float(v) = v {
+            Ok(v)
+        } else {
+            Err(v)
+        }
+    }
+}
+
+impl From<i32> for UnionFloatInt {
+    fn from(v: i32) -> Self {
+        Self::Int(v)
+    }
+}
+
+impl TryFrom<UnionFloatInt> for i32 {
+    type Error = UnionFloatInt;
+
+    fn try_from(v: UnionFloatInt) -> Result<Self, Self::Error> {
+        if let UnionFloatInt::Int(v) = v {
+            Ok(v)
+        } else {
+            Err(v)
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct FooBar {
+    pub test_vec: Vec<f32>,
+    pub float_union: UnionFloatInt,
+    pub int_union: UnionIntLong,
+}
+
+#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct FooFoo {
+    pub test_map: ::std::collections::HashMap<String, f32>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct BarFoo {
+    pub nested_int: i32,
+}
+
+#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct Baz {
+    #[serde(rename = "FooFoo")]
+    pub foo_foo: FooFoo,
+    #[serde(rename = "FooBar")]
+    pub foo_bar: FooBar,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct FooBaz {
+    #[serde(rename = "BarFoo")]
+    pub bar_foo: BarFoo,
+}
+
+#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct Bar {
+    #[serde(rename = "Baz")]
+    pub baz: Baz,
+}
+
+#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct Foo {
+    #[serde(rename = "Bar")]
+    pub bar: Bar,
+    #[serde(rename = "FooBaz")]
+    pub foo_baz: FooBaz,
+}

--- a/tests/schemas/nullable.rs
+++ b/tests/schemas/nullable.rs
@@ -1,5 +1,5 @@
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct Test {
     #[serde(deserialize_with = "nullable_test_a")]

--- a/tests/schemas/optional_array.rs
+++ b/tests/schemas/optional_array.rs
@@ -1,5 +1,5 @@
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct Variable {
     pub oid: Option<Vec<i64>>,
@@ -21,7 +21,7 @@ impl Default for Variable {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct TrapV1 {
     pub var: Option<Vec<Variable>>,
@@ -38,7 +38,7 @@ impl Default for TrapV1 {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct V1 {
     pub pdu: Option<TrapV1>,
@@ -55,7 +55,7 @@ impl Default for V1 {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct Snmp {
     pub v1: Option<V1>,

--- a/tests/schemas/optional_arrays.rs
+++ b/tests/schemas/optional_arrays.rs
@@ -1,5 +1,5 @@
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct KsqlDataSourceSchema {
     #[serde(rename = "ID")]

--- a/tests/schemas/record_default.rs
+++ b/tests/schemas/record_default.rs
@@ -1,10 +1,10 @@
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Info {
     pub name: String,
 }
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct User {
     pub info: Info,

--- a/tests/schemas/record_multiline_doc.rs
+++ b/tests/schemas/record_multiline_doc.rs
@@ -1,7 +1,7 @@
 
 /// Some user representation
 /// Users love pizzas!
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct User {
     pub likes_pizza: bool,

--- a/tests/schemas/simple.rs
+++ b/tests/schemas/simple.rs
@@ -1,5 +1,5 @@
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Test {
     #[serde(default = "default_test_a")]
     pub a: i64,

--- a/tests/schemas/simple_with_builders.rs
+++ b/tests/schemas/simple_with_builders.rs
@@ -1,5 +1,5 @@
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize, derive_builder::Builder)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize, derive_builder::Builder)]
 #[builder(setter(into))]
 pub struct Test {
     #[serde(default = "default_test_a")]

--- a/tests/schemas/simple_with_schemas.rs
+++ b/tests/schemas/simple_with_schemas.rs
@@ -1,5 +1,5 @@
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize, apache_avro::AvroSchema)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize, apache_avro::AvroSchema)]
 pub struct Test {
     #[serde(default = "default_test_a")]
     pub a: i64,


### PR DESCRIPTION
Add derive `Eq` for all types that does not consist nested float type.