### PR TITLE
Fix inconsistent enum default name generation

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1032,7 +1032,7 @@ impl Templater {
                     Value::String(ref s) => {
                         let s = sanitize(s.to_upper_camel_case());
                         if valids.contains(&s) {
-                            format!("{}::{}", e_name, sanitize(s.to_upper_camel_case()))
+                            format!("{}::{}", e_name, s)
                         } else {
                             err!("Invalid default: {:?}", default)?
                         }


### PR DESCRIPTION
When working on a project that performs code generation from Avro schema files, I have encountered an issue with enums. This seems to be an edge case that is easy to overlook, but the generated code does not compile. The problem is when an enum is defined as a struct field and has a default symbol that is only two characters long, starts with a small letter, and ends with a capital letter (e.g. `mJ`, see example below).

Minimal example:
```avsc
{
    "type": "record",
    "name": "MyRecord",
    "namespace": "com.example.data",
    "doc": "Record doc",
    "fields": [
        {
            "name": "id",
            "type": "int",
            "doc": "Identifier"
        },
        {
            "name": "unit",
            "type": {
                "type": "enum",
                "name": "MeasurementUnit",
                "symbols": [
                    "mJ"
                ]
            },
            "doc": "Measurement unit",
            "default": "mJ"
        }
    ]
}
```

The issue manifests itself at line 1035 of `src/templates.rs`, where `s.to_upper_camel_case()` is called twice when constructing the default symbol name (in contrast, this method is called only once when generating the enum definition). For the example above, the sequence of modifications is as follows: `mJ -> MJ -> Mj`.

The generated code looks as follows:

```rust
#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize)]
pub enum MeasurementUnit {
    #[serde(rename = "mJ")]
    MJ,
}

/// Record doc
#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
pub struct MyRecord {
    pub id: i32,
    #[serde(default = "default_myrecord_unit")]
    pub unit: MeasurementUnit,
}

#[inline(always)]
fn default_myrecord_unit() -> MeasurementUnit { MeasurementUnit::Mj }
```

See the difference between `MeasurementUnit::MJ` and `MeasurementUnit::Mj`. The proposed change is minimal and makes sure that `s.to_upper_camel_case()` is called only once both when generating the enum definition and when generating the default initializer function inside the record.