### PR TITLE
Split CLI binary from the library crate

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -57,7 +57,7 @@ jobs:
           rustup update stable
           rustup default stable
           rustup target add ${{ matrix.job.target }}
-          cargo build --release --target ${{ matrix.job.target }}
+          cargo build --features full --release --target ${{ matrix.job.target }}
       - name: Create tarball
         run: |
           TARBALL=rsgen-avro-${{ needs.release.outputs.tag }}-${{ matrix.job.target }}.tar.gz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - run: |
           rustup update ${{ matrix.toolchain }}
           rustup default ${{ matrix.toolchain }}
-      - run: cargo build
+      - run: cargo build --features full
       - run: cargo fmt --check --all
       - run: cargo clippy -- -D warnings
       - run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 apache-avro = { version = "0.15", features = ["derive"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive"], optional = true }
 glob = "0.3"
 heck = "0.4"
 lazy_static = "1"
@@ -34,3 +34,11 @@ opt-level = "z"   # Optimize for size.
 lto = true
 codegen-units = 1
 strip = true
+
+[features]
+full = ["build-cli"]
+build-cli = ["dep:clap"]
+
+[[bin]]
+name = "rsgen-avro"
+required-features = ["build-cli"]


### PR DESCRIPTION
I am using `rsgen-avro` at work for Rust code generation based on Avro schema files. The application we are building is for an IoT system that is run on a custom Yocto linux build. We are using `rsgen-avro` as a library (we do not use the generated CLI binary). The issue with the `rsgen-avro>=0.12.0` is the dependency on `clap@4`. Since the latter installs the most recent version, which is `clap@4.4.1` as of today, it requires at least Rust 1.70 to compile. Unfortunately, the latest supported Rust version on Yocto today is 1.68 (see [1] and [2]).

With the current structure of the package, we are stuck on `rsgen-avro@0.11.1` until Yocto project supports at least Rust 1.70. We would greatly benefit from using the latest version, `rsgen-avro>=0.12.2`, but this requires modifying slightly the package structure.

With this change I propose to split the binary generation from the library crate using a feature flag. One can still generate the binary, if needed (and it will be done by the CI/CD pipeline), but the benefit is that the library crate does not depend on `clap@4` and therefore any other package that uses `rsgen-avro` as a library skips installing `clap` as dependency.

[1] https://docs.yoctoproject.org/dev/migration-guides/release-notes-4.2.html
[2] https://wiki.yoctoproject.org/wiki/Releases