### PR TITLE
Updated Apache-avro dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-apache-avro = { version = "0.15", features = ["derive"] }
+apache-avro = { version = "0.16", features = ["derive"] }
 clap = { version = "4", features = ["derive"], optional = true }
 glob = "0.3"
 heck = "0.4"


### PR DESCRIPTION
Reference: https://rustsec.org/advisories/RUSTSEC-2023-0074

apache-avro. 0.16 doesn't have a dependency on zerocopy, and therefore avoids this security advisory