### PR TITLE
Fix serde visitor for byts with `use_avro_rs_unions` option

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -323,7 +323,7 @@ impl GeneratorBuilder {
     /// Adds support for deserializing union types from the `apache-avro` crate.
     ///
     /// Only necessary for unions of 3 or more types or 2-type unions without "null".
-    /// Note that only int, long, float, double, and boolean values are currently supported.
+    /// Note that only int, long, float, double, boolean and bytes values are currently supported.
     pub fn use_avro_rs_unions(mut self, use_avro_rs_unions: bool) -> GeneratorBuilder {
         self.use_avro_rs_unions = use_avro_rs_unions;
         self

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -179,7 +179,7 @@ impl<'de> serde::Deserialize<'de> for {{ name }} {
             {%- for v in visitors %}
             {%- if v.serde_visitor %}
 
-            fn visit_{{ v.serde_visitor | trim_start_matches(pat="&") }}<E>(self, value: {{ v.serde_visitor }}) -> Result<Self::Value, E>
+            fn visit_{{ v.serde_visitor | replace(from="&[u8]", to="bytes") | trim_start_matches(pat="&") }}<E>(self, value: {{ v.serde_visitor }}) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {

--- a/tests/schemas/multi_valued_union_with_avro_rs_unions.avsc
+++ b/tests/schemas/multi_valued_union_with_avro_rs_unions.avsc
@@ -5,6 +5,6 @@
   "fields": [ {
     "name": "extra",
     "type": "map",
-    "values" : [ "null", "string", "long", "double", "boolean" ]
+    "values" : [ "null", "string", "long", "double", "boolean", "bytes" ]
   } ]
 }

--- a/tests/schemas/multi_valued_union_with_avro_rs_unions.rs
+++ b/tests/schemas/multi_valued_union_with_avro_rs_unions.rs
@@ -1,24 +1,25 @@
 
 /// Auto-generated type for unnamed Avro union variants.
 #[derive(Debug, PartialEq, Clone, serde::Serialize)]
-pub enum UnionStringLongDoubleBoolean {
+pub enum UnionStringLongDoubleBooleanBytes {
     String(String),
     Long(i64),
     Double(f64),
     Boolean(bool),
+    Bytes(#[serde(with = "apache_avro::serde_avro_bytes")] Vec<u8>),
 }
 
-impl From<String> for UnionStringLongDoubleBoolean {
+impl From<String> for UnionStringLongDoubleBooleanBytes {
     fn from(v: String) -> Self {
         Self::String(v)
     }
 }
 
-impl TryFrom<UnionStringLongDoubleBoolean> for String {
-    type Error = UnionStringLongDoubleBoolean;
+impl TryFrom<UnionStringLongDoubleBooleanBytes> for String {
+    type Error = UnionStringLongDoubleBooleanBytes;
 
-    fn try_from(v: UnionStringLongDoubleBoolean) -> Result<Self, Self::Error> {
-        if let UnionStringLongDoubleBoolean::String(v) = v {
+    fn try_from(v: UnionStringLongDoubleBooleanBytes) -> Result<Self, Self::Error> {
+        if let UnionStringLongDoubleBooleanBytes::String(v) = v {
             Ok(v)
         } else {
             Err(v)
@@ -26,17 +27,17 @@ impl TryFrom<UnionStringLongDoubleBoolean> for String {
     }
 }
 
-impl From<i64> for UnionStringLongDoubleBoolean {
+impl From<i64> for UnionStringLongDoubleBooleanBytes {
     fn from(v: i64) -> Self {
         Self::Long(v)
     }
 }
 
-impl TryFrom<UnionStringLongDoubleBoolean> for i64 {
-    type Error = UnionStringLongDoubleBoolean;
+impl TryFrom<UnionStringLongDoubleBooleanBytes> for i64 {
+    type Error = UnionStringLongDoubleBooleanBytes;
 
-    fn try_from(v: UnionStringLongDoubleBoolean) -> Result<Self, Self::Error> {
-        if let UnionStringLongDoubleBoolean::Long(v) = v {
+    fn try_from(v: UnionStringLongDoubleBooleanBytes) -> Result<Self, Self::Error> {
+        if let UnionStringLongDoubleBooleanBytes::Long(v) = v {
             Ok(v)
         } else {
             Err(v)
@@ -44,17 +45,17 @@ impl TryFrom<UnionStringLongDoubleBoolean> for i64 {
     }
 }
 
-impl From<f64> for UnionStringLongDoubleBoolean {
+impl From<f64> for UnionStringLongDoubleBooleanBytes {
     fn from(v: f64) -> Self {
         Self::Double(v)
     }
 }
 
-impl TryFrom<UnionStringLongDoubleBoolean> for f64 {
-    type Error = UnionStringLongDoubleBoolean;
+impl TryFrom<UnionStringLongDoubleBooleanBytes> for f64 {
+    type Error = UnionStringLongDoubleBooleanBytes;
 
-    fn try_from(v: UnionStringLongDoubleBoolean) -> Result<Self, Self::Error> {
-        if let UnionStringLongDoubleBoolean::Double(v) = v {
+    fn try_from(v: UnionStringLongDoubleBooleanBytes) -> Result<Self, Self::Error> {
+        if let UnionStringLongDoubleBooleanBytes::Double(v) = v {
             Ok(v)
         } else {
             Err(v)
@@ -62,17 +63,17 @@ impl TryFrom<UnionStringLongDoubleBoolean> for f64 {
     }
 }
 
-impl From<bool> for UnionStringLongDoubleBoolean {
+impl From<bool> for UnionStringLongDoubleBooleanBytes {
     fn from(v: bool) -> Self {
         Self::Boolean(v)
     }
 }
 
-impl TryFrom<UnionStringLongDoubleBoolean> for bool {
-    type Error = UnionStringLongDoubleBoolean;
+impl TryFrom<UnionStringLongDoubleBooleanBytes> for bool {
+    type Error = UnionStringLongDoubleBooleanBytes;
 
-    fn try_from(v: UnionStringLongDoubleBoolean) -> Result<Self, Self::Error> {
-        if let UnionStringLongDoubleBoolean::Boolean(v) = v {
+    fn try_from(v: UnionStringLongDoubleBooleanBytes) -> Result<Self, Self::Error> {
+        if let UnionStringLongDoubleBooleanBytes::Boolean(v) = v {
             Ok(v)
         } else {
             Err(v)
@@ -80,55 +81,80 @@ impl TryFrom<UnionStringLongDoubleBoolean> for bool {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for UnionStringLongDoubleBoolean {
-    fn deserialize<D>(deserializer: D) -> Result<UnionStringLongDoubleBoolean, D::Error>
+impl From<Vec<u8>> for UnionStringLongDoubleBooleanBytes {
+    fn from(v: Vec<u8>) -> Self {
+        Self::Bytes(v)
+    }
+}
+
+impl TryFrom<UnionStringLongDoubleBooleanBytes> for Vec<u8> {
+    type Error = UnionStringLongDoubleBooleanBytes;
+
+    fn try_from(v: UnionStringLongDoubleBooleanBytes) -> Result<Self, Self::Error> {
+        if let UnionStringLongDoubleBooleanBytes::Bytes(v) = v {
+            Ok(v)
+        } else {
+            Err(v)
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for UnionStringLongDoubleBooleanBytes {
+    fn deserialize<D>(deserializer: D) -> Result<UnionStringLongDoubleBooleanBytes, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         /// Serde visitor for the auto-generated unnamed Avro union type.
-        struct UnionStringLongDoubleBooleanVisitor;
+        struct UnionStringLongDoubleBooleanBytesVisitor;
 
-        impl<'de> serde::de::Visitor<'de> for UnionStringLongDoubleBooleanVisitor {
-            type Value = UnionStringLongDoubleBoolean;
+        impl<'de> serde::de::Visitor<'de> for UnionStringLongDoubleBooleanBytesVisitor {
+            type Value = UnionStringLongDoubleBooleanBytes;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("a UnionStringLongDoubleBoolean")
+                formatter.write_str("a UnionStringLongDoubleBooleanBytes")
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
-                Ok(UnionStringLongDoubleBoolean::String(value.into()))
+                Ok(UnionStringLongDoubleBooleanBytes::String(value.into()))
             }
 
             fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
-                Ok(UnionStringLongDoubleBoolean::Long(value.into()))
+                Ok(UnionStringLongDoubleBooleanBytes::Long(value.into()))
             }
 
             fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
-                Ok(UnionStringLongDoubleBoolean::Double(value.into()))
+                Ok(UnionStringLongDoubleBooleanBytes::Double(value.into()))
             }
 
             fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
-                Ok(UnionStringLongDoubleBoolean::Boolean(value.into()))
+                Ok(UnionStringLongDoubleBooleanBytes::Boolean(value.into()))
+            }
+
+            fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(UnionStringLongDoubleBooleanBytes::Bytes(value.into()))
             }
         }
 
-        deserializer.deserialize_any(UnionStringLongDoubleBooleanVisitor)
+        deserializer.deserialize_any(UnionStringLongDoubleBooleanBytesVisitor)
     }
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Contact {
-    pub extra: ::std::collections::HashMap<String, Option<UnionStringLongDoubleBoolean>>,
+    pub extra: ::std::collections::HashMap<String, Option<UnionStringLongDoubleBooleanBytes>>,
 }


### PR DESCRIPTION
NOTE: I don't know how to really test if the deserialization is successful but at least it builds now.

Sorry, missed that in https://github.com/lerouxrgd/rsgen-avro/pull/69 and it results in this error when enabling [use_avro_rs_unions](https://docs.rs/rsgen-avro/latest/rsgen_avro/struct.GeneratorBuilder.html#method.use_avro_rs_unions):
```
error: expected one of `->`, `<`, `where`, or `{`, found `[`
   --> <generated_file>:100:22
    |
86  |         impl<'de> serde::de::Visitor<'de> for UnionStringBytesVisitor {
    |                                                                       - while parsing this item list starting here
...
100 |             fn visit_[u8]<E>(self, value: &[u8]) -> Result<Self::Value, E>
    |                      ^ expected one of `->`, `<`, `where`, or `{`
...
106 |         }
    |         - the item list ends here
```