### PR TITLE
fix: optional chrono types

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -883,7 +883,31 @@ impl Templater {
                             && matches!(union.variants()[1], Schema::Fixed(_))
                         {
                             w.insert(name_std.clone(), "apache_avro::serde_avro_fixed_opt");
-                        }
+                        } else if union.is_nullable()
+                            && union.variants().len() == 2
+                            && matches!(
+                                union.variants()[1],
+                                Schema::TimestampMillis | Schema::LocalTimestampMillis
+                            )
+                        {
+                            w.insert(name_std.clone(), "chrono::serde::ts_milliseconds_option");
+                        } else if union.is_nullable()
+                            && union.variants().len() == 2
+                            && matches!(
+                                union.variants()[1],
+                                Schema::TimestampMicros | Schema::LocalTimestampMicros
+                            )
+                        {
+                            w.insert(name_std.clone(), "chrono::serde::ts_microseconds_option");
+                        } else if union.is_nullable()
+                            && union.variants().len() == 2
+                            && matches!(
+                                union.variants()[1],
+                                Schema::TimestampNanos | Schema::LocalTimestampNanos
+                            )
+                        {
+                            w.insert(name_std.clone(), "chrono::serde::ts_nanoseconds_option");
+                        };
                     }
 
                     Schema::Null => err!("Invalid use of Schema::Null")?,

--- a/tests/schemas/logical_dates.rs
+++ b/tests/schemas/logical_dates.rs
@@ -4,6 +4,7 @@
 pub struct DateLogicalType {
     #[serde(with = "chrono::serde::ts_seconds")]
     pub birthday: chrono::DateTime<chrono::Utc>,
+    #[serde(with = "chrono::serde::ts_milliseconds_option")]
     #[serde(default = "default_datelogicaltype_meeting_time")]
     pub meeting_time: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(with = "chrono::serde::ts_microseconds")]


### PR DESCRIPTION
Fix deserialization issue of optional chrono types

`Error while deserializing message payload Failed to deserialize Avro value into value: Expected a String|Bytes|Fixed|Uuid, but got TimestampMillis(....)`