### PR TITLE
wrap recursive optionals with Box<>

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1735,12 +1735,8 @@ pub(crate) fn option_type(inner: &Schema, gen_state: &GenState) -> Result<String
         }
 
         Schema::Record(rec) => {
-            let recursive = rec.fields.iter().any(|f| {
-                matches!(&f.schema, Schema::Union(scm) if scm.variants().iter().any(|v|
-                    matches!(v, Schema::Ref { name } if name == &rec.name)
-                ))
-            });
-            if recursive {
+            let schema = Schema::Record(rec.clone());
+            if find_recursion(&rec.name.name, &schema) {
                 format!(
                     "Option<Box<{}>>",
                     &sanitize(rec.name.name.to_upper_camel_case())
@@ -1757,4 +1753,36 @@ pub(crate) fn option_type(inner: &Schema, gen_state: &GenState) -> Result<String
         Schema::Null => err!("Invalid use of Schema::Null")?,
     };
     Ok(type_str)
+}
+
+fn find_recursion(name: &str, schema: &Schema) -> bool {
+    match schema {
+        Schema::Record(rec) => {
+            if rec.name.name == name {
+                return true;
+            } else {
+                for field in rec.fields.iter() {
+                    if find_recursion(name, &field.schema) {
+                        return true;
+                    }
+                }
+            }
+        }
+        Schema::Union(scm) => {
+            for variant in scm.variants().iter() {
+                if find_recursion(name, variant) {
+                    return true;
+                }
+            }
+        }
+        Schema::Ref { name: r_name } => {
+            if r_name.name == name {
+                return true;
+            }
+        }
+        _ => {
+            return false;
+        }
+    }
+    false
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1736,7 +1736,7 @@ pub(crate) fn option_type(inner: &Schema, gen_state: &GenState) -> Result<String
 
         Schema::Record(rec) => {
             let schema = Schema::Record(rec.clone());
-            if find_recursion(&rec.name.name, &schema) {
+            if find_recursion(&rec.name, &schema) {
                 format!(
                     "Option<Box<{}>>",
                     &sanitize(rec.name.name.to_upper_camel_case())
@@ -1755,16 +1755,12 @@ pub(crate) fn option_type(inner: &Schema, gen_state: &GenState) -> Result<String
     Ok(type_str)
 }
 
-fn find_recursion(name: &str, schema: &Schema) -> bool {
+fn find_recursion(name: &Name, schema: &Schema) -> bool {
     match schema {
         Schema::Record(rec) => {
-            if rec.name.name == name {
-                return true;
-            } else {
-                for field in rec.fields.iter() {
-                    if find_recursion(name, &field.schema) {
-                        return true;
-                    }
+            for field in rec.fields.iter() {
+                if find_recursion(name, &field.schema) {
+                    return true;
                 }
             }
         }
@@ -1776,13 +1772,11 @@ fn find_recursion(name: &str, schema: &Schema) -> bool {
             }
         }
         Schema::Ref { name: r_name } => {
-            if r_name.name == name {
+            if r_name == name {
                 return true;
             }
         }
-        _ => {
-            return false;
-        }
+        _ => {}
     }
     false
 }

--- a/tests/schemas/recursive.avsc
+++ b/tests/schemas/recursive.avsc
@@ -1,21 +1,105 @@
-{"type": "record", "name":"RecursiveType",
- "fields": [
-   {"name": "field_a", "type":
-    {"type": "record", "name": "Rec",
-     "fields": [
-       {"name": "label", "type": "string"},
-       {"name": "children", "type": {"type": "array", "items": "Rec"}},
-       {"name": "floatField", "type": "float"}
-     ]}},
-   {"name": "field_b", "type":
-    {"type": "record", "name": "Node",
-     "fields": [
-       {"name": "label", "type": "string"},
-       {"name": "children", "type": {"type": "array", "items": "Node"}}]}},
-   {"name": "field_c", "type":
-    {"type": "record", "name": "Parent",
-     "fields": [
-      {"name": "label", "type": "string"},
-      {"name": "parent", "type": ["null", "Parent"], "default": null}]}}
- ]
+{
+  "type": "record",
+  "name": "RecursiveType",
+  "fields": [
+    {
+      "name": "field_a",
+      "type": {
+        "type": "record",
+        "name": "Rec",
+        "fields": [
+          {
+            "name": "label",
+            "type": "string"
+          },
+          {
+            "name": "children",
+            "type": {
+              "type": "array",
+              "items": "Rec"
+            }
+          },
+          {
+            "name": "floatField",
+            "type": "float"
+          }
+        ]
+      }
+    },
+    {
+      "name": "field_b",
+      "type": {
+        "type": "record",
+        "name": "Node",
+        "fields": [
+          {
+            "name": "label",
+            "type": "string"
+          },
+          {
+            "name": "children",
+            "type": {
+              "type": "array",
+              "items": "Node"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "direct_parent",
+      "type": {
+        "type": "record",
+        "name": "Parent",
+        "fields": [
+          {
+            "name": "label",
+            "type": "string"
+          },
+          {
+            "name": "parent",
+            "type": [
+              "null",
+              "Parent"
+            ],
+            "default": null
+          }
+        ]
+      }
+    },
+    {
+      "name": "nested_parent",
+      "type": {
+        "type": "record",
+        "name": "Metadata",
+        "fields": [
+          {
+            "name": "label",
+            "type": "string"
+          },
+          {
+            "name": "additional",
+            "type": {
+              "type": "record",
+              "name": "Additional",
+              "fields": [
+                {
+                  "name": "field_x",
+                  "type": "string"
+                },
+                {
+                  "name": "parent",
+                  "type": [
+                    "null",
+                    "Metadata"
+                  ],
+                  "default": null
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/tests/schemas/recursive.avsc
+++ b/tests/schemas/recursive.avsc
@@ -11,6 +11,11 @@
     {"type": "record", "name": "Node",
      "fields": [
        {"name": "label", "type": "string"},
-       {"name": "children", "type": {"type": "array", "items": "Node"}}]}}
+       {"name": "children", "type": {"type": "array", "items": "Node"}}]}},
+   {"name": "field_c", "type":
+    {"type": "record", "name": "Parent",
+     "fields": [
+      {"name": "label", "type": "string"},
+      {"name": "parent", "type": ["null", "Parent"], "default": null}]}}
  ]
 }

--- a/tests/schemas/recursive.rs
+++ b/tests/schemas/recursive.rs
@@ -1,5 +1,15 @@
 
 #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct Parent {
+    pub label: String,
+    #[serde(default = "default_parent_parent")]
+    pub parent: Option<Box<Parent>>,
+}
+
+#[inline(always)]
+fn default_parent_parent() -> Option<Box<Parent>> { None }
+
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Node {
     pub label: String,
     pub children: Vec<Node>,
@@ -17,4 +27,5 @@ pub struct Rec {
 pub struct RecursiveType {
     pub field_a: Rec,
     pub field_b: Node,
+    pub field_c: Parent,
 }

--- a/tests/schemas/recursive.rs
+++ b/tests/schemas/recursive.rs
@@ -1,5 +1,21 @@
 
 #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct Additional {
+    pub field_x: String,
+    #[serde(default = "default_additional_parent")]
+    pub parent: Option<Box<Metadata>>,
+}
+
+#[inline(always)]
+fn default_additional_parent() -> Option<Box<Metadata>> { None }
+
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct Metadata {
+    pub label: String,
+    pub additional: Additional,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Parent {
     pub label: String,
     #[serde(default = "default_parent_parent")]
@@ -27,5 +43,6 @@ pub struct Rec {
 pub struct RecursiveType {
     pub field_a: Rec,
     pub field_b: Node,
-    pub field_c: Parent,
+    pub direct_parent: Parent,
+    pub nested_parent: Metadata,
 }


### PR DESCRIPTION
This wraps recursive fields which are optional with a Box<> to prevent infinite recursion and make the generated code compile.