### PR TITLE
Prefixed namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Options:
       --derive-builders  Derive builders for generated record structs
       --derive-schemas   Derive AvroSchema for generated record structs
       --extra_derives    Append extra derive macros list to the generated record structs
+      --prefix-namespace Prefix the namespace(if any) to generated types
   -h, --help             Print help
   -V, --version          Print version
 ```

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -286,6 +286,7 @@ pub struct GeneratorBuilder {
     derive_builders: bool,
     derive_schemas: bool,
     extra_derives: Vec<String>,
+    prefix_namespace: bool,
 }
 
 impl Default for GeneratorBuilder {
@@ -298,6 +299,7 @@ impl Default for GeneratorBuilder {
             derive_builders: false,
             derive_schemas: false,
             extra_derives: vec![],
+            prefix_namespace: false,
         }
     }
 }
@@ -361,6 +363,11 @@ impl GeneratorBuilder {
         self
     }
 
+    pub fn prefix_namespace(mut self, prefix_namespace: bool) -> GeneratorBuilder {
+        self.prefix_namespace = prefix_namespace;
+        self
+    }
+
     /// Create a [`Generator`](Generator) with the builder parameters.
     pub fn build(self) -> Result<Generator> {
         let mut templater = Templater::new()?;
@@ -371,6 +378,7 @@ impl GeneratorBuilder {
         templater.derive_builders = self.derive_builders;
         templater.derive_schemas = self.derive_schemas;
         templater.extra_derives = self.extra_derives;
+        templater.prefix_namespace = self.prefix_namespace;
         Ok(Generator { templater })
     }
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -130,7 +130,7 @@ impl Generator {
                     }
 
                     // Register inner union for it to be used as a nested type later
-                    let type_str = union_type(union, &gs, true)?;
+                    let type_str = union_type(union, &gs, true, self.templater.prefix_namespace)?;
                     gs.put_type(&s, type_str)
                 }
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -110,13 +110,13 @@ impl Generator {
                 Schema::Array(ArraySchema {
                     items: ref inner, ..
                 }) => {
-                    let type_str = array_type(inner, &gs)?;
+                    let type_str = array_type(inner, &gs, self.templater.prefix_namespace)?;
                     gs.put_type(&s, type_str)
                 }
                 Schema::Map(MapSchema {
                     types: ref inner, ..
                 }) => {
-                    let type_str = map_type(inner, &gs)?;
+                    let type_str = map_type(inner, &gs, self.templater.prefix_namespace)?;
                     gs.put_type(&s, type_str)
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,10 @@ struct Args {
     /// Extract Derives for generated record structs, comma separated, e.g. `std::fmt::Display,std::string::ToString`
     #[clap(long, value_delimiter = ',')]
     pub extra_derives: Vec<String>,
+
+    /// Prefix namespace to name
+    #[clap(long)]
+    pub prefix_namespace: bool,
 }
 
 fn run() -> Result<(), Box<dyn Error>> {
@@ -75,6 +79,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         .derive_builders(args.derive_builders)
         .derive_schemas(args.derive_schemas)
         .extra_derives(args.extra_derives)
+        .prefix_namespace(args.prefix_namespace)
         .build()?;
 
     g.generate(&source, &mut out)?;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1749,8 +1749,7 @@ pub(crate) fn option_type(inner: &Schema, gen_state: &GenState) -> Result<String
             name: Name { name, .. },
             ..
         }) => format!("Option<{}>", &sanitize(name.to_upper_camel_case())),
-
-        Schema::Null => String::from("null"), // Schema::Null => err!("Invalid use of Schema::Null in option")?,
+        Schema::Null => err!("Invalid use of Schema::Null in option")?,
     };
     Ok(type_str)
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1750,8 +1750,7 @@ pub(crate) fn option_type(inner: &Schema, gen_state: &GenState) -> Result<String
             ..
         }) => format!("Option<{}>", &sanitize(name.to_upper_camel_case())),
 
-        Schema::Null => {}
-        // Schema::Null => err!("Invalid use of Schema::Null in option")?,
+        Schema::Null => String::from("null"), // Schema::Null => err!("Invalid use of Schema::Null in option")?,
     };
     Ok(type_str)
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1750,7 +1750,8 @@ pub(crate) fn option_type(inner: &Schema, gen_state: &GenState) -> Result<String
             ..
         }) => format!("Option<{}>", &sanitize(name.to_upper_camel_case())),
 
-        Schema::Null => err!("Invalid use of Schema::Null in option")?,
+        Schema::Null => {}
+        // Schema::Null => err!("Invalid use of Schema::Null in option")?,
     };
     Ok(type_str)
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -819,7 +819,7 @@ impl Templater {
                     }
 
                     Schema::Array(ArraySchema { items: inner, .. }) => match inner.as_ref() {
-                        Schema::Null => err!("Invalid use of Schema::Null")?,
+                        Schema::Null => err!("Invalid use of Schema::Null in {:?}", inner.name())?,
                         _ => {
                             let type_str = array_type(inner, gen_state)?;
                             f.push(name_std.clone());
@@ -832,7 +832,7 @@ impl Templater {
                     },
 
                     Schema::Map(MapSchema { types: inner, .. }) => match inner.as_ref() {
-                        Schema::Null => err!("Invalid use of Schema::Null")?,
+                        Schema::Null => err!("Invalid use of Schema::Null in {:?}", inner.name())?,
                         _ => {
                             let type_str = map_type(inner, gen_state)?;
                             f.push(name_std.clone());
@@ -918,7 +918,7 @@ impl Templater {
                         };
                     }
 
-                    Schema::Null => err!("Invalid use of Schema::Null")?,
+                    Schema::Null => err!("Invalid use of Schema::Null in {:?}", schema.name())?,
                 };
             }
 
@@ -1279,12 +1279,12 @@ impl Templater {
             },
 
             Schema::Array(ArraySchema { items: inner, .. }) => match inner.as_ref() {
-                Schema::Null => err!("Invalid use of Schema::Null")?,
+                Schema::Null => err!("Invalid use of Schema::Null in {:?}", inner.name())?,
                 _ => self.array_default(inner, gen_state, default)?,
             },
 
             Schema::Map(MapSchema { types: inner, .. }) => match inner.as_ref() {
-                Schema::Null => err!("Invalid use of Schema::Null")?,
+                Schema::Null => err!("Invalid use of Schema::Null in {:?}", inner.name())?,
                 _ => self.map_default(inner, gen_state, default)?,
             },
 
@@ -1315,7 +1315,7 @@ impl Templater {
 
             Schema::Union(union) => self.union_default(union, gen_state, default)?,
 
-            Schema::Null => err!("Invalid use of Schema::Null")?,
+            Schema::Null => err!("Invalid use of Schema::Null in {:?}", schema.name())?,
         };
 
         Ok(default_str)
@@ -1503,7 +1503,7 @@ pub(crate) fn array_type(inner: &Schema, gen_state: &GenState) -> Result<String>
             ..
         }) => format!("Vec<{}>", &sanitize(name.to_upper_camel_case())),
 
-        Schema::Null => err!("Invalid use of Schema::Null")?,
+        Schema::Null => err!("Invalid use of Schema::Null in {:?}", inner.name())?,
     };
     Ok(type_str)
 }
@@ -1580,7 +1580,7 @@ pub(crate) fn map_type(inner: &Schema, gen_state: &GenState) -> Result<String> {
             ..
         }) => map_of(&sanitize(name.to_upper_camel_case())),
 
-        Schema::Null => err!("Invalid use of Schema::Null")?,
+        Schema::Null => err!("Invalid use of Schema::Null in {:?}", inner.name())?,
     };
     Ok(type_str)
 }
@@ -1754,7 +1754,7 @@ pub(crate) fn option_type(inner: &Schema, gen_state: &GenState) -> Result<String
             ..
         }) => format!("Option<{}>", &sanitize(name.to_upper_camel_case())),
 
-        Schema::Null => err!("Invalid use of Schema::Null")?,
+        Schema::Null => err!("Invalid use of Schema::Null in {:?}", inner.name())?,
     };
     Ok(type_str)
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -808,11 +808,13 @@ impl Templater {
                         }
                     }
 
-                    Schema::Fixed(FixedSchema {
-                        name: Name { name: f_name, .. },
-                        ..
-                    }) => {
-                        let f_name = sanitize(f_name.to_upper_camel_case());
+                    Schema::Fixed(FixedSchema { name, .. }) => {
+                        let f_name;
+                        if self.prefix_namespace {
+                            f_name = sanitize(name.fullname(None).to_upper_camel_case());
+                        } else {
+                            f_name = sanitize(name.name.to_upper_camel_case());
+                        }
                         f.push(name_std.clone());
                         w.insert(name_std.clone(), "apache_avro::serde_avro_fixed");
                         t.insert(name_std.clone(), f_name.clone());
@@ -848,11 +850,13 @@ impl Templater {
                         }
                     },
 
-                    Schema::Record(RecordSchema {
-                        name: Name { name: r_name, .. },
-                        ..
-                    }) => {
-                        let r_name = sanitize(r_name.to_upper_camel_case());
+                    Schema::Record(RecordSchema { name, .. }) => {
+                        let r_name;
+                        if self.prefix_namespace {
+                            r_name = sanitize(name.fullname(None).to_upper_camel_case());
+                        } else {
+                            r_name = sanitize(name.name.to_upper_camel_case());
+                        }
                         f.push(name_std.clone());
                         t.insert(name_std.clone(), r_name.clone());
                         if let Some(default) = default {
@@ -861,11 +865,13 @@ impl Templater {
                         }
                     }
 
-                    Schema::Enum(EnumSchema {
-                        name: Name { name: e_name, .. },
-                        ..
-                    }) => {
-                        let e_name = sanitize(e_name.to_upper_camel_case());
+                    Schema::Enum(EnumSchema { name, .. }) => {
+                        let e_name;
+                        if self.prefix_namespace {
+                            e_name = sanitize(name.fullname(None).to_upper_camel_case());
+                        } else {
+                            e_name = sanitize(name.name.to_upper_camel_case());
+                        }
                         f.push(name_std.clone());
                         t.insert(name_std.clone(), e_name);
                         if let Some(default) = default {

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -819,7 +819,7 @@ impl Templater {
                     }
 
                     Schema::Array(ArraySchema { items: inner, .. }) => match inner.as_ref() {
-                        Schema::Null => err!("Invalid use of Schema::Null in {:?}", inner.name())?,
+                        Schema::Null => err!("Invalid use of Schema::Null in inner record.array")?,
                         _ => {
                             let type_str = array_type(inner, gen_state)?;
                             f.push(name_std.clone());
@@ -832,7 +832,7 @@ impl Templater {
                     },
 
                     Schema::Map(MapSchema { types: inner, .. }) => match inner.as_ref() {
-                        Schema::Null => err!("Invalid use of Schema::Null in {:?}", inner.name())?,
+                        Schema::Null => err!("Invalid use of Schema::Null in inner record.map")?,
                         _ => {
                             let type_str = map_type(inner, gen_state)?;
                             f.push(name_std.clone());
@@ -918,7 +918,7 @@ impl Templater {
                         };
                     }
 
-                    Schema::Null => err!("Invalid use of Schema::Null in {:?}", schema.name())?,
+                    Schema::Null => err!("Invalid use of Schema::Null in record")?,
                 };
             }
 
@@ -1279,12 +1279,12 @@ impl Templater {
             },
 
             Schema::Array(ArraySchema { items: inner, .. }) => match inner.as_ref() {
-                Schema::Null => err!("Invalid use of Schema::Null in {:?}", inner.name())?,
+                Schema::Null => err!("Invalid use of Schema::Null in inner array")?,
                 _ => self.array_default(inner, gen_state, default)?,
             },
 
             Schema::Map(MapSchema { types: inner, .. }) => match inner.as_ref() {
-                Schema::Null => err!("Invalid use of Schema::Null in {:?}", inner.name())?,
+                Schema::Null => err!("Invalid use of Schema::Null in inner map")?,
                 _ => self.map_default(inner, gen_state, default)?,
             },
 
@@ -1315,7 +1315,7 @@ impl Templater {
 
             Schema::Union(union) => self.union_default(union, gen_state, default)?,
 
-            Schema::Null => err!("Invalid use of Schema::Null in {:?}", schema.name())?,
+            Schema::Null => err!("Invalid use of Schema::Null in default")?,
         };
 
         Ok(default_str)
@@ -1503,7 +1503,7 @@ pub(crate) fn array_type(inner: &Schema, gen_state: &GenState) -> Result<String>
             ..
         }) => format!("Vec<{}>", &sanitize(name.to_upper_camel_case())),
 
-        Schema::Null => err!("Invalid use of Schema::Null in {:?}", inner.name())?,
+        Schema::Null => err!("Invalid use of Schema::Null in array")?,
     };
     Ok(type_str)
 }
@@ -1580,7 +1580,7 @@ pub(crate) fn map_type(inner: &Schema, gen_state: &GenState) -> Result<String> {
             ..
         }) => map_of(&sanitize(name.to_upper_camel_case())),
 
-        Schema::Null => err!("Invalid use of Schema::Null in {:?}", inner.name())?,
+        Schema::Null => err!("Invalid use of Schema::Null in map")?,
     };
     Ok(type_str)
 }
@@ -1754,7 +1754,7 @@ pub(crate) fn option_type(inner: &Schema, gen_state: &GenState) -> Result<String
             ..
         }) => format!("Option<{}>", &sanitize(name.to_upper_camel_case())),
 
-        Schema::Null => err!("Invalid use of Schema::Null in {:?}", inner.name())?,
+        Schema::Null => err!("Invalid use of Schema::Null in option")?,
     };
     Ok(type_str)
 }

--- a/tests/generation.rs
+++ b/tests/generation.rs
@@ -255,3 +255,11 @@ fn gen_two_extra_derives() {
             .unwrap(),
     );
 }
+
+#[test]
+fn gen_prefixed_namespace() {
+    validate_generation(
+        "prefixed_namespaces",
+        Generator::builder().prefix_namespace(true).build().unwrap(),
+    );
+}

--- a/tests/schemas/mod.rs
+++ b/tests/schemas/mod.rs
@@ -34,3 +34,4 @@ pub mod simple;
 pub mod simple_with_builders;
 pub mod simple_with_schemas;
 pub mod nested_with_float;
+pub mod prefixed_namespaces;

--- a/tests/schemas/prefixed_namespaces.avsc
+++ b/tests/schemas/prefixed_namespaces.avsc
@@ -1,0 +1,77 @@
+{
+  "type": "record",
+  "name": "SomeRecord",
+  "namespace": "some.ns",
+  "fields": [
+    {
+      "name": "label",
+      "type": "string"
+    },
+    {
+      "name": "parent",
+      "type": [
+        "null",
+        "some.ns.SomeRecord"
+      ],
+      "default": null
+    },
+    {
+      "name": "children",
+      "type": {
+        "type": "array",
+        "items": "some.ns.SomeRecord"
+      }
+    },
+    {
+      "name": "status",
+      "type": {
+        "type": "enum",
+        "name": "Status",
+        "namespace": "another.ns",
+        "symbols": [
+          "ACTIVE",
+          "PAUSED",
+          "INACTIVE"
+        ]
+      }
+    },
+    {
+      "name": "metadata_a",
+      "type": {
+        "type": "record",
+        "name": "Metadata",
+        "namespace": "some.ns.a",
+        "fields": [
+          {
+            "name": "label",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "metadata_b",
+      "type": {
+        "type": "record",
+        "name": "Metadata",
+        "namespace": "some.ns.b",
+        "fields": [
+          {
+            "name": "cost",
+            "type": "int"
+          }
+        ]
+      }
+    },
+    {
+      "name": "union_field",
+      "type": [
+        "some.ns.a.Metadata",
+        "some.ns.b.Metadata"
+      ],
+      "default": {
+        "label": "default_label"
+      }
+    }
+  ]
+}

--- a/tests/schemas/prefixed_namespaces.avsc
+++ b/tests/schemas/prefixed_namespaces.avsc
@@ -72,6 +72,19 @@
       "default": {
         "label": "default_label"
       }
+    },
+    {
+      "name": "record_without_ns",
+      "type": {
+        "type": "record",
+        "name": "my_record",
+        "fields": [
+          {
+            "name": "some_field",
+            "type": "boolean"
+          }
+        ]
+      }
     }
   ]
 }

--- a/tests/schemas/prefixed_namespaces.rs
+++ b/tests/schemas/prefixed_namespaces.rs
@@ -1,0 +1,154 @@
+
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct SomeNsBMetadata {
+    pub cost: i32,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct SomeNsAMetadata {
+    pub label: String,
+}
+
+/// Auto-generated type for unnamed Avro union variants.
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(remote = "Self")]
+pub enum UnionSomeNsAMetadataSomeNsBMetadata {
+    SomeNsAMetadata(SomeNsAMetadata),
+    SomeNsBMetadata(SomeNsBMetadata),
+}
+
+impl From<SomeNsAMetadata> for UnionSomeNsAMetadataSomeNsBMetadata {
+    fn from(v: SomeNsAMetadata) -> Self {
+        Self::SomeNsAMetadata(v)
+    }
+}
+
+impl TryFrom<UnionSomeNsAMetadataSomeNsBMetadata> for SomeNsAMetadata {
+    type Error = UnionSomeNsAMetadataSomeNsBMetadata;
+
+    fn try_from(v: UnionSomeNsAMetadataSomeNsBMetadata) -> Result<Self, Self::Error> {
+        if let UnionSomeNsAMetadataSomeNsBMetadata::SomeNsAMetadata(v) = v {
+            Ok(v)
+        } else {
+            Err(v)
+        }
+    }
+}
+
+impl From<SomeNsBMetadata> for UnionSomeNsAMetadataSomeNsBMetadata {
+    fn from(v: SomeNsBMetadata) -> Self {
+        Self::SomeNsBMetadata(v)
+    }
+}
+
+impl TryFrom<UnionSomeNsAMetadataSomeNsBMetadata> for SomeNsBMetadata {
+    type Error = UnionSomeNsAMetadataSomeNsBMetadata;
+
+    fn try_from(v: UnionSomeNsAMetadataSomeNsBMetadata) -> Result<Self, Self::Error> {
+        if let UnionSomeNsAMetadataSomeNsBMetadata::SomeNsBMetadata(v) = v {
+            Ok(v)
+        } else {
+            Err(v)
+        }
+    }
+}
+
+impl serde::Serialize for UnionSomeNsAMetadataSomeNsBMetadata {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        struct NewtypeVariantSerializer<S>(S);
+
+        impl<S> serde::Serializer for NewtypeVariantSerializer<S>
+        where
+            S: serde::Serializer,
+        {
+            type Ok = S::Ok;
+            type Error = S::Error;
+            type SerializeSeq = serde::ser::Impossible<S::Ok, S::Error>;
+            type SerializeTuple = serde::ser::Impossible<S::Ok, S::Error>;
+            type SerializeTupleStruct = serde::ser::Impossible<S::Ok, S::Error>;
+            type SerializeTupleVariant = serde::ser::Impossible<S::Ok, S::Error>;
+            type SerializeMap = serde::ser::Impossible<S::Ok, S::Error>;
+            type SerializeStruct = serde::ser::Impossible<S::Ok, S::Error>;
+            type SerializeStructVariant = serde::ser::Impossible<S::Ok, S::Error>;
+            fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_none(self) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_some<T: ?Sized + serde::Serialize>(self, _value: &T) -> Result<Self::Ok, Self::Error>{ unimplemented!() }
+            fn serialize_unit(self) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_unit_variant(self ,_name: &'static str, _variant_index: u32, _variant: &'static str) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_newtype_struct<T: ?Sized + serde::Serialize>(self, _name: &'static str, _value: &T,) -> Result<Self::Ok, Self::Error> { unimplemented!() }
+            fn serialize_seq(self,_len: Option<usize>,) -> Result<Self::SerializeSeq, Self::Error> { unimplemented!() }
+            fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> { unimplemented!() }
+            fn serialize_tuple_struct(self,_name: &'static str,_len: usize) -> Result<Self::SerializeTupleStruct, Self::Error> { unimplemented!() }
+            fn serialize_tuple_variant(self,_name: &'static str,_variant_index: u32,_variant: &'static str,_len: usize) -> Result<Self::SerializeTupleVariant, Self::Error> { unimplemented!() }
+            fn serialize_map(self,_len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> { unimplemented!() }
+            fn serialize_struct(self,_name: &'static str,_len: usize) -> Result<Self::SerializeStruct, Self::Error> { unimplemented!() }
+            fn serialize_struct_variant(self,_name: &'static str,_variant_index: u32,_variant: &'static str,_len: usize) -> Result<Self::SerializeStructVariant, Self::Error> { unimplemented!() }
+            fn serialize_newtype_variant<T: ?Sized + serde::Serialize>(
+                self,
+                _name: &'static str,
+                _variant_index: u32,
+                _variant: &'static str,
+                value: &T,
+            ) -> Result<Self::Ok, Self::Error> {
+                value.serialize(self.0)
+            }
+        }
+
+        Self::serialize(self, NewtypeVariantSerializer(serializer))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for UnionSomeNsAMetadataSomeNsBMetadata {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::deserialize(deserializer)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize)]
+pub enum AnotherNsStatus {
+    #[serde(rename = "ACTIVE")]
+    Active,
+    #[serde(rename = "PAUSED")]
+    Paused,
+    #[serde(rename = "INACTIVE")]
+    Inactive,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct SomeNsSomeRecord {
+    pub label: String,
+    #[serde(default = "default_somenssomerecord_parent")]
+    pub parent: Option<Box<SomeNsSomeRecord>>,
+    pub children: Vec<SomeNsSomeRecord>,
+    pub status: AnotherNsStatus,
+    pub metadata_a: SomeNsAMetadata,
+    pub metadata_b: SomeNsBMetadata,
+    #[serde(default = "default_somenssomerecord_union_field")]
+    pub union_field: UnionSomeNsAMetadataSomeNsBMetadata,
+}
+
+#[inline(always)]
+fn default_somenssomerecord_parent() -> Option<Box<SomeNsSomeRecord>> { None }
+
+#[inline(always)]
+fn default_somenssomerecord_union_field() -> UnionSomeNsAMetadataSomeNsBMetadata { UnionSomeNsAMetadataSomeNsBMetadata::SomeNsAMetadata(SomeNsAMetadata { label: "default_label".to_owned(), }) }

--- a/tests/schemas/prefixed_namespaces.rs
+++ b/tests/schemas/prefixed_namespaces.rs
@@ -1,5 +1,10 @@
 
 #[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct SomeNsMyRecord {
+    pub some_field: bool,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
 pub struct SomeNsBMetadata {
     pub cost: i32,
 }
@@ -145,6 +150,7 @@ pub struct SomeNsSomeRecord {
     pub metadata_b: SomeNsBMetadata,
     #[serde(default = "default_somenssomerecord_union_field")]
     pub union_field: UnionSomeNsAMetadataSomeNsBMetadata,
+    pub record_without_ns: SomeNsMyRecord,
 }
 
 #[inline(always)]


### PR DESCRIPTION
This MR adds the option to prefix namespaces to generated types.
This is necessary if you have types in multiple namespaces with the same names or having fields with the same name.