### PR TITLE
chore: fix clippy lints

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ pub enum Error {
     #[error("Unexpected io error: {}", .0)]
     Io(#[from] std::io::Error),
     #[error("Avro error: {}", .0)]
-    Avro(#[from] apache_avro::Error),
+    Avro(#[from] Box<apache_avro::Error>),
     #[error("Invalid glob pattern: {}", .0)]
     GlobPattern(#[from] glob::PatternError),
 }
@@ -18,6 +18,12 @@ pub enum Error {
 impl From<tera::Error> for Error {
     fn from(source: tera::Error) -> Self {
         Error::Template(source.to_string())
+    }
+}
+
+impl From<apache_avro::Error> for Error {
+    fn from(source: apache_avro::Error) -> Self {
+        Error::Avro(source.into())
     }
 }
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -134,7 +134,7 @@ impl Generator {
                     gs.put_type(&s, type_str)
                 }
 
-                _ => return Err(Error::Schema(format!("Not a valid root schema: {:?}", s))),
+                _ => return Err(Error::Schema(format!("Not a valid root schema: {s:?}"))),
             }
         }
 
@@ -425,7 +425,7 @@ mod tests {
         );
 
         let s = deps.pop();
-        assert!(matches!(s, None));
+        assert!(s.is_none());
     }
 
     #[test]

--- a/tests/generation.rs
+++ b/tests/generation.rs
@@ -81,13 +81,12 @@ fn gen_multi_valued_union_map() {
 
 #[test]
 fn gen_multi_valued_union_nested() {
-    let schemas = format!("tests/schemas/multi_valued_union_nested_*.avsc");
-    let src = Source::GlobPattern(&schemas);
+    let schemas = "tests/schemas/multi_valued_union_nested_*.avsc";
+    let src = Source::GlobPattern(schemas);
     let mut buf = vec![];
     Generator::new().unwrap().generate(&src, &mut buf).unwrap();
     let generated = String::from_utf8(buf).unwrap();
-    let expected =
-        std::fs::read_to_string(format!("tests/schemas/multi_valued_union_nested.rs")).unwrap();
+    let expected = std::fs::read_to_string("tests/schemas/multi_valued_union_nested.rs").unwrap();
     validate(expected, generated)
 }
 

--- a/tests/schemas/mod.rs
+++ b/tests/schemas/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 pub mod array_3d;
 pub mod complex;
 pub mod decimals;


### PR DESCRIPTION
This fixes the following lints:
 - redundant_pattern_matching
 - unneeded_struct_pattern
 - useless_format
 - uninlined_format_args
   * this lint will moved from `pedantic` to `style` in the next Rust release.
 - result_large_err
   * this one would be less severe with [avro-rs#194](https://github.com/apache/avro-rs/pull/194) but 88 bytes is still really big when the rest is all 24 bytes.

I've also disabled lints for `tests/schemas` where the generated code lives.