### PR TITLE
feat: Allow to override (part of) the generated code for a field (no CLI support)

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::io::prelude::*;
 
-use apache_avro::schema::{ArraySchema, DecimalSchema, MapSchema, RecordField, RecordSchema};
+use apache_avro::schema::{ArraySchema, DecimalSchema, MapSchema, Name, RecordField, RecordSchema};
 
 use crate::Schema;
 use crate::error::{Error, Result};
@@ -86,7 +86,8 @@ impl Generator {
     /// * Keeps tracks of nested schema->name with `GenState` mapping
     /// * Appends generated Rust types to the output
     fn gen_in_order(&self, deps: &mut Vec<Schema>, output: &mut impl Write) -> Result<()> {
-        let mut gs = GenState::new(deps)?.with_chrono_dates(self.templater.use_chrono_dates);
+        let mut gs = GenState::new(deps, &self.templater.field_overrides)?
+            .with_chrono_dates(self.templater.use_chrono_dates);
 
         while let Some(s) = deps.pop() {
             match s {
@@ -286,6 +287,7 @@ pub struct GeneratorBuilder {
     derive_builders: bool,
     impl_schemas: ImplementAvroSchema,
     extra_derives: Vec<String>,
+    field_overrides: HashMap<Name, Vec<FieldOverride>>,
 }
 
 impl Default for GeneratorBuilder {
@@ -298,6 +300,7 @@ impl Default for GeneratorBuilder {
             derive_builders: false,
             impl_schemas: ImplementAvroSchema::None,
             extra_derives: vec![],
+            field_overrides: HashMap::new(),
         }
     }
 }
@@ -336,6 +339,42 @@ impl std::fmt::Display for ImplementAvroSchema {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{self:?}")
     }
+}
+
+/// Override (part of) the generated code for a [`Schema`] field.
+///
+/// Currently only possible for Record schemas.
+///
+/// When changing the type of the field, `implements_eq` must also be changed.
+/// `serde_with` and `default` might also need to be changed. If this is not done
+/// it will result in a compiler error.
+#[derive(Debug, Clone)]
+
+pub struct FieldOverride {
+    /// Name of the schema the field is in.
+    pub schema: Name,
+    /// Name of the field as in the schema.
+    pub field: String,
+    /// Change the documentation of the field.
+    pub docstring: Option<String>,
+    /// Change the type of the field.
+    ///
+    /// This type *must* implement [`Debug`], [`PartialEq`], and [`Clone`].
+    /// If extra derives are configured (including `Builder` and [`AvroSchema`](apache_avro::AvroSchema))
+    /// then the type *must* also implement these.
+    pub type_name: Option<String>,
+    /// Does the type implement [`Eq`].
+    ///
+    /// This *must* be set if the type is changed.
+    pub implements_eq: Option<bool>,
+    /// Module name to use for `#[serde(with = ...)]`.
+    ///
+    /// This *must* be set if the type was changed and the type does not implement `Serialize` or `Deserialize`.
+    pub serde_with: Option<String>,
+    /// Default value for this field, can be a function call that generates the default value.
+    ///
+    /// This *must* be set if the field is nullable and the type was changed and the outer type is not an [`Option`].
+    pub default: Option<String>,
 }
 
 impl GeneratorBuilder {
@@ -402,6 +441,30 @@ impl GeneratorBuilder {
         self
     }
 
+    /// Override (part of) the code generated for a field.
+    ///
+    /// Applies to record structs.
+    pub fn override_fields(mut self, overrides: Vec<FieldOverride>) -> GeneratorBuilder {
+        for over in overrides {
+            self.field_overrides
+                .entry(over.schema.clone())
+                .or_default()
+                .push(over);
+        }
+        self
+    }
+
+    /// Override (part of) the code generated for a field.
+    ///
+    /// Applies to record structs.
+    pub fn override_field(mut self, over: FieldOverride) -> GeneratorBuilder {
+        self.field_overrides
+            .entry(over.schema.clone())
+            .or_default()
+            .push(over);
+        self
+    }
+
     /// Create a [`Generator`](Generator) with the builder parameters.
     pub fn build(self) -> Result<Generator> {
         let mut templater = Templater::new()?;
@@ -413,6 +476,7 @@ impl GeneratorBuilder {
         templater.derive_schemas = self.impl_schemas == ImplementAvroSchema::Derive;
         templater.impl_schemas = self.impl_schemas == ImplementAvroSchema::CopyBuildSchema;
         templater.extra_derives = self.extra_derives;
+        templater.field_overrides = self.field_overrides;
         Ok(Generator { templater })
     }
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -86,8 +86,12 @@ impl Generator {
     /// * Keeps tracks of nested schema->name with `GenState` mapping
     /// * Appends generated Rust types to the output
     fn gen_in_order(&self, deps: &mut Vec<Schema>, output: &mut impl Write) -> Result<()> {
-        let mut gs = GenState::new(deps, &self.templater.field_overrides)?
-            .with_chrono_dates(self.templater.use_chrono_dates);
+        let mut gs = GenState::new(deps)?.with_chrono_dates(self.templater.use_chrono_dates);
+
+        if !self.templater.field_overrides.is_empty() {
+            // This rechecks no_eq for all schemas, so only do it if there are actually overrides.
+            gs = gs.with_field_overrides(deps, &self.templater.field_overrides)?;
+        }
 
         while let Some(s) = deps.pop() {
             match s {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,9 @@ mod generator;
 mod templates;
 
 pub use crate::error::{Error, Result};
-pub use crate::generator::{Generator, GeneratorBuilder, ImplementAvroSchema, Source};
+pub use crate::generator::{
+    FieldOverride, Generator, GeneratorBuilder, ImplementAvroSchema, Source,
+};
 
 pub use apache_avro;
 pub use apache_avro::Schema;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -344,10 +344,7 @@ pub struct GenState {
 }
 
 impl GenState {
-    pub fn new(
-        deps: &[Schema],
-        field_overrides: &HashMap<Name, Vec<FieldOverride>>,
-    ) -> Result<Self> {
+    pub fn new(deps: &[Schema]) -> Result<Self> {
         let schemata_by_name: HashMap<Name, Schema> = deps
             .iter()
             .filter_map(|s| match s {
@@ -357,13 +354,22 @@ impl GenState {
                 _ => None,
             })
             .collect::<HashMap<_, _>>();
-        let not_eq = Self::get_not_eq_schemata(deps, &schemata_by_name, field_overrides)?;
+        let not_eq = Self::get_not_eq_schemata(deps, &schemata_by_name, &HashMap::new())?;
         Ok(GenState {
             types_by_schema: HashMap::new(),
             schemata_by_name,
             not_eq,
             use_chrono_dates: false,
         })
+    }
+
+    pub fn with_field_overrides(
+        mut self,
+        deps: &[Schema],
+        field_overrides: &HashMap<Name, Vec<FieldOverride>>,
+    ) -> Result<Self> {
+        self.not_eq = Self::get_not_eq_schemata(deps, &self.schemata_by_name, field_overrides)?;
+        Ok(self)
     }
 
     pub fn with_chrono_dates(mut self, use_chrono_dates: bool) -> Self {

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -16,6 +16,7 @@ use serde_json::Value;
 use tera::{Context, Tera};
 
 use crate::error::{Error, Result};
+use crate::generator::FieldOverride;
 
 pub const RECORD_TERA: &str = "record.tera";
 pub const RECORD_TEMPLATE: &str = r##"
@@ -44,10 +45,10 @@ pub struct {{ name }} {
     {%- if f != originals[f] and not f is starting_with("r#") %}
     #[serde(rename = "{{ originals[f] }}")]
     {%- endif %}
-    {%- if nullable and not type is starting_with("Option") %}
+    {%- if nullable and not type is starting_with("Option<") %}
     #[serde(deserialize_with = "nullable_{{ name|lower }}_{{ f }}")]
     {%- endif %}
-    {%- if nullable and not type is starting_with("Option") and serde_with is containing(f) %}
+    {%- if nullable and not type is starting_with("Option<") and serde_with is containing(f) %}
     #[serde(serialize_with = "{{ serde_with[f] }}::serialize")]
     {%- endif %}
     {%- if not nullable and serde_with is containing(f) %}
@@ -62,7 +63,7 @@ pub struct {{ name }} {
 
 {%- for f in fields %}
 {%- set type = types[f] %}
-{%- if nullable and not type is starting_with("Option") %}
+{%- if nullable and not type is starting_with("Option<") %}
 {# #}
 #[inline(always)]
 fn nullable_{{ name|lower }}_{{ f }}<'de, D>(deserializer: D) -> Result<{{ type }}, D::Error>
@@ -343,7 +344,10 @@ pub struct GenState {
 }
 
 impl GenState {
-    pub fn new(deps: &[Schema]) -> Result<Self> {
+    pub fn new(
+        deps: &[Schema],
+        field_overrides: &HashMap<Name, Vec<FieldOverride>>,
+    ) -> Result<Self> {
         let schemata_by_name: HashMap<Name, Schema> = deps
             .iter()
             .filter_map(|s| match s {
@@ -353,7 +357,7 @@ impl GenState {
                 _ => None,
             })
             .collect::<HashMap<_, _>>();
-        let not_eq = Self::get_not_eq_schemata(deps, &schemata_by_name)?;
+        let not_eq = Self::get_not_eq_schemata(deps, &schemata_by_name, field_overrides)?;
         Ok(GenState {
             types_by_schema: HashMap::new(),
             schemata_by_name,
@@ -398,6 +402,7 @@ impl GenState {
     fn deep_search_not_eq(
         schema: &Schema,
         schemata_by_name: &HashMap<Name, Schema>,
+        field_overrides: &HashMap<Name, Vec<FieldOverride>>,
         inner_not_eq: &mut HashMap<Name, bool>,
         outer_not_eq: &mut HashMap<Name, bool>,
     ) -> Result<bool> {
@@ -408,12 +413,26 @@ impl GenState {
                     not_eq.insert(false);
                 }
             }
+            if let Some(overrides) = field_overrides.get(name) {
+                for over in overrides {
+                    if let Some(impls_eq) = over.implements_eq {
+                        inner_not_eq.insert(name.clone(), !impls_eq);
+                        outer_not_eq.insert(name.clone(), !impls_eq);
+                        return Ok(!impls_eq);
+                    }
+                }
+            }
         }
         match schema {
             Schema::Array(ArraySchema { items: inner, .. })
             | Schema::Map(MapSchema { types: inner, .. }) => {
-                let not_eq =
-                    Self::deep_search_not_eq(inner, schemata_by_name, inner_not_eq, outer_not_eq)?;
+                let not_eq = Self::deep_search_not_eq(
+                    inner,
+                    schemata_by_name,
+                    field_overrides,
+                    inner_not_eq,
+                    outer_not_eq,
+                )?;
                 match schema.name() {
                     Some(schema_name) if not_eq => {
                         inner_not_eq.insert(schema_name.clone(), true);
@@ -428,6 +447,7 @@ impl GenState {
                     let not_eq = Self::deep_search_not_eq(
                         &f.schema,
                         schemata_by_name,
+                        field_overrides,
                         inner_not_eq,
                         outer_not_eq,
                     )?;
@@ -448,7 +468,13 @@ impl GenState {
             }
             Schema::Union(union) => {
                 for s in union.variants() {
-                    if Self::deep_search_not_eq(s, schemata_by_name, inner_not_eq, outer_not_eq)? {
+                    if Self::deep_search_not_eq(
+                        s,
+                        schemata_by_name,
+                        field_overrides,
+                        inner_not_eq,
+                        outer_not_eq,
+                    )? {
                         return Ok(true);
                     }
                 }
@@ -462,8 +488,13 @@ impl GenState {
                 })?;
                 inner_not_eq.remove(name); // Force re-exploration of the ref schema
                 outer_not_eq.remove(name); // Force re-exploration of the ref schema
-                let not_eq =
-                    Self::deep_search_not_eq(schema, schemata_by_name, inner_not_eq, outer_not_eq)?;
+                let not_eq = Self::deep_search_not_eq(
+                    schema,
+                    schemata_by_name,
+                    field_overrides,
+                    inner_not_eq,
+                    outer_not_eq,
+                )?;
                 match schema.name() {
                     Some(schema_name) if not_eq => {
                         inner_not_eq.insert(schema_name.clone(), true);
@@ -482,6 +513,7 @@ impl GenState {
     fn get_not_eq_schemata(
         deps: &[Schema],
         schemata_by_name: &HashMap<Name, Schema>,
+        field_overrides: &HashMap<Name, Vec<FieldOverride>>,
     ) -> Result<HashSet<String>> {
         let mut schemata_not_eq = HashSet::new();
         let mut outer_not_eq = HashMap::new();
@@ -490,6 +522,7 @@ impl GenState {
             let not_eq = Self::deep_search_not_eq(
                 dep,
                 schemata_by_name,
+                field_overrides,
                 &mut inner_not_eq,
                 &mut outer_not_eq,
             )?;
@@ -523,6 +556,7 @@ pub struct Templater {
     pub derive_schemas: bool,
     pub impl_schemas: bool,
     pub extra_derives: Vec<String>,
+    pub field_overrides: HashMap<Name, Vec<FieldOverride>>,
 }
 
 impl Templater {
@@ -546,6 +580,7 @@ impl Templater {
             derive_schemas: false,
             impl_schemas: false,
             extra_derives: vec![],
+            field_overrides: HashMap::new(),
         })
     }
 
@@ -603,12 +638,11 @@ impl Templater {
     /// Makes use of a [`GenState`](GenState) for nested schemas (i.e. Array/Map/Union).
     pub fn str_record(&self, schema: &Schema, gen_state: &GenState) -> Result<String> {
         if let Schema::Record(RecordSchema {
-            name: Name { name, .. },
-            fields,
-            doc,
-            ..
+            name, fields, doc, ..
         }) = schema
         {
+            let full_name = name;
+            let name = &full_name.name;
             let mut ctx = Context::new();
             ctx.insert("name", &name.to_upper_camel_case());
             let doc = if let Some(d) = doc { d } else { "" };
@@ -657,8 +691,31 @@ impl Templater {
             {
                 let name_std = sanitize(name.to_snake_case());
                 o.insert(name_std.clone(), name);
-                if let Some(d) = doc {
+
+                let field_override = self
+                    .field_overrides
+                    .get(full_name)
+                    .and_then(|fs| fs.iter().find(|f| &f.field == name));
+                if let Some(over) = field_override
+                    && let Some(d) = &over.docstring
+                {
                     c.insert(name_std.clone(), d);
+                } else if let Some(d) = doc {
+                    c.insert(name_std.clone(), d);
+                }
+
+                if let Some(field_override) = field_override
+                    && let Some(type_name) = &field_override.type_name
+                {
+                    f.push(name_std.clone());
+                    t.insert(name_std.clone(), type_name.to_string());
+                    if let Some(with) = &field_override.serde_with {
+                        w.insert(name_std.clone(), with.clone());
+                    }
+                    if let Some(default) = &field_override.default {
+                        d.insert(name_std.clone(), default.clone());
+                    }
+                    continue;
                 }
 
                 let schema = if let Schema::Ref { name } = schema {
@@ -686,7 +743,7 @@ impl Templater {
                             name_std.clone(),
                             "chrono::DateTime<chrono::Utc>".to_string(),
                         );
-                        w.insert(name_std.clone(), "chrono::serde::ts_seconds");
+                        w.insert(name_std.clone(), "chrono::serde::ts_seconds".to_string());
                         if let Some(default) = default {
                             let default = self.parse_default(schema, gen_state, default)?;
                             d.insert(name_std.clone(), default);
@@ -701,7 +758,10 @@ impl Templater {
                             name_std.clone(),
                             "chrono::DateTime<chrono::Utc>".to_string(),
                         );
-                        w.insert(name_std.clone(), "chrono::serde::ts_milliseconds");
+                        w.insert(
+                            name_std.clone(),
+                            "chrono::serde::ts_milliseconds".to_string(),
+                        );
                         if let Some(default) = default {
                             let default = self.parse_default(schema, gen_state, default)?;
                             d.insert(name_std.clone(), default);
@@ -716,7 +776,10 @@ impl Templater {
                             name_std.clone(),
                             "chrono::DateTime<chrono::Utc>".to_string(),
                         );
-                        w.insert(name_std.clone(), "chrono::serde::ts_microseconds");
+                        w.insert(
+                            name_std.clone(),
+                            "chrono::serde::ts_microseconds".to_string(),
+                        );
                         if let Some(default) = default {
                             let default = self.parse_default(schema, gen_state, default)?;
                             d.insert(name_std.clone(), default);
@@ -731,7 +794,10 @@ impl Templater {
                             name_std.clone(),
                             "chrono::DateTime<chrono::Utc>".to_string(),
                         );
-                        w.insert(name_std.clone(), "chrono::serde::ts_nanoseconds");
+                        w.insert(
+                            name_std.clone(),
+                            "chrono::serde::ts_nanoseconds".to_string(),
+                        );
                         if let Some(default) = default {
                             let default = self.parse_default(schema, gen_state, default)?;
                             d.insert(name_std.clone(), default);
@@ -784,7 +850,10 @@ impl Templater {
                     Schema::Bytes => {
                         f.push(name_std.clone());
                         t.insert(name_std.clone(), "Vec<u8>".to_string());
-                        w.insert(name_std.clone(), "apache_avro::serde_avro_bytes");
+                        w.insert(
+                            name_std.clone(),
+                            "apache_avro::serde_avro_bytes".to_string(),
+                        );
                         if let Some(default) = default {
                             let default = self.parse_default(schema, gen_state, default)?;
                             d.insert(name_std.clone(), default);
@@ -842,7 +911,10 @@ impl Templater {
                     }) => {
                         let f_name = sanitize(f_name.to_upper_camel_case());
                         f.push(name_std.clone());
-                        w.insert(name_std.clone(), "apache_avro::serde_avro_fixed");
+                        w.insert(
+                            name_std.clone(),
+                            "apache_avro::serde_avro_fixed".to_string(),
+                        );
                         t.insert(name_std.clone(), f_name.clone());
                         if let Some(default) = default {
                             let default = self.parse_default(schema, gen_state, default)?;
@@ -914,12 +986,18 @@ impl Templater {
                             && union.variants().len() == 2
                             && matches!(union.variants()[1], Schema::Bytes)
                         {
-                            w.insert(name_std.clone(), "apache_avro::serde_avro_bytes_opt");
+                            w.insert(
+                                name_std.clone(),
+                                "apache_avro::serde_avro_bytes_opt".to_string(),
+                            );
                         } else if union.is_nullable()
                             && union.variants().len() == 2
                             && matches!(union.variants()[1], Schema::Fixed(_))
                         {
-                            w.insert(name_std.clone(), "apache_avro::serde_avro_fixed_opt");
+                            w.insert(
+                                name_std.clone(),
+                                "apache_avro::serde_avro_fixed_opt".to_string(),
+                            );
                         } else if union.is_nullable()
                             && union.variants().len() == 2
                             && matches!(
@@ -928,7 +1006,10 @@ impl Templater {
                             )
                             && self.use_chrono_dates
                         {
-                            w.insert(name_std.clone(), "chrono::serde::ts_milliseconds_option");
+                            w.insert(
+                                name_std.clone(),
+                                "chrono::serde::ts_milliseconds_option".to_string(),
+                            );
                         } else if union.is_nullable()
                             && union.variants().len() == 2
                             && matches!(
@@ -937,7 +1018,10 @@ impl Templater {
                             )
                             && self.use_chrono_dates
                         {
-                            w.insert(name_std.clone(), "chrono::serde::ts_microseconds_option");
+                            w.insert(
+                                name_std.clone(),
+                                "chrono::serde::ts_microseconds_option".to_string(),
+                            );
                         } else if union.is_nullable()
                             && union.variants().len() == 2
                             && matches!(
@@ -946,7 +1030,10 @@ impl Templater {
                             )
                             && self.use_chrono_dates
                         {
-                            w.insert(name_std.clone(), "chrono::serde::ts_nanoseconds_option");
+                            w.insert(
+                                name_std.clone(),
+                                "chrono::serde::ts_nanoseconds_option".to_string(),
+                            );
                         };
                     }
 

--- a/tests/generation.rs
+++ b/tests/generation.rs
@@ -73,7 +73,7 @@ fn gen_simple_with_field_override() {
                 docstring: Some("The IP-address associated with this Avro".to_string()),
                 type_name: Some("std::net::IpAddr".to_string()),
                 implements_eq: Some(true),
-                serde_with: Some("super::ip_addr_serde".to_string()),
+                serde_with: Some("super::utils::ip_addr_serde".to_string()),
                 default: None,
             })
             .build()

--- a/tests/generation.rs
+++ b/tests/generation.rs
@@ -1,8 +1,9 @@
 #[rustfmt::skip]
 mod schemas;
 
+use apache_avro::schema::Name;
 use pretty_assertions::assert_eq;
-use rsgen_avro::{Generator, ImplementAvroSchema, Source};
+use rsgen_avro::{FieldOverride, Generator, ImplementAvroSchema, Source};
 
 fn validate_generation(file_name: &str, g: Generator) {
     let schema = format!("tests/schemas/{file_name}.avsc");
@@ -53,6 +54,50 @@ fn gen_simple_with_schema_impl() {
         "simple_with_schemas_impl",
         Generator::builder()
             .implement_avro_schema(ImplementAvroSchema::CopyBuildSchema)
+            .build()
+            .unwrap(),
+    );
+}
+
+#[test]
+fn gen_simple_with_field_override() {
+    validate_generation(
+        "simple_with_override",
+        Generator::builder()
+            .override_field(FieldOverride {
+                schema: Name {
+                    name: "test_override".to_string(),
+                    namespace: None,
+                },
+                field: "ip_addr".to_string(),
+                docstring: Some("The IP-address associated with this Avro".to_string()),
+                type_name: Some("std::net::IpAddr".to_string()),
+                implements_eq: Some(true),
+                serde_with: Some("super::ip_addr_serde".to_string()),
+                default: None,
+            })
+            .build()
+            .unwrap(),
+    );
+}
+
+#[test]
+fn gen_simple_with_field_override_no_eq() {
+    validate_generation(
+        "simple_with_override_no_eq",
+        Generator::builder()
+            .override_field(FieldOverride {
+                schema: Name {
+                    name: "test_override_no_eq".to_string(),
+                    namespace: None,
+                },
+                field: "a".to_string(),
+                docstring: None,
+                type_name: Some("f64".to_string()),
+                implements_eq: Some(false),
+                serde_with: None,
+                default: Some("42.0".to_string()),
+            })
             .build()
             .unwrap(),
     );

--- a/tests/schemas/mod.rs
+++ b/tests/schemas/mod.rs
@@ -33,7 +33,49 @@ pub mod record_multiline_doc;
 pub mod recursive;
 pub mod simple;
 pub mod simple_with_builders;
+pub mod simple_with_override;
 pub mod simple_with_schemas;
 pub mod simple_with_schemas_impl;
 pub mod nested_with_schemas_impl;
 pub mod nested_with_float;
+
+/// For testing field overrides in simple_with_override
+mod ip_addr_serde {
+    use std::{fmt::Formatter, net::IpAddr};
+    use serde::{de::{Error, Visitor}, Deserializer, Serializer};
+
+    pub fn serialize<S>(value: &IpAddr, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        match value {
+            IpAddr::V4(ipv4_addr) => serializer.serialize_bytes(&ipv4_addr.octets()),
+            IpAddr::V6(ipv6_addr) => serializer.serialize_bytes(&ipv6_addr.octets()),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<IpAddr, D::Error> where D: Deserializer<'de> {
+        struct IpVisitor;
+        impl Visitor<'_> for IpVisitor {
+            type Value = IpAddr;
+
+            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+                formatter.write_str("an IPv4 address as bytes")
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E> 
+            where E: Error {
+                match v.len() {
+                    4 => {
+                        let bytes: [u8; 4] = v.try_into().unwrap();
+                        Ok(IpAddr::from(bytes))
+                    }
+                    16 => {
+                        let bytes: [u8; 16] = v.try_into().unwrap();
+                        Ok(IpAddr::from(bytes))
+                    }
+                    _ => Err(Error::custom("Invalid IP address byte length")),
+                }
+            }
+        }
+
+        deserializer.deserialize_bytes(IpVisitor)
+    }
+}

--- a/tests/schemas/mod.rs
+++ b/tests/schemas/mod.rs
@@ -39,43 +39,4 @@ pub mod simple_with_schemas_impl;
 pub mod nested_with_schemas_impl;
 pub mod nested_with_float;
 
-/// For testing field overrides in simple_with_override
-mod ip_addr_serde {
-    use std::{fmt::Formatter, net::IpAddr};
-    use serde::{de::{Error, Visitor}, Deserializer, Serializer};
-
-    pub fn serialize<S>(value: &IpAddr, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-        match value {
-            IpAddr::V4(ipv4_addr) => serializer.serialize_bytes(&ipv4_addr.octets()),
-            IpAddr::V6(ipv6_addr) => serializer.serialize_bytes(&ipv6_addr.octets()),
-        }
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<IpAddr, D::Error> where D: Deserializer<'de> {
-        struct IpVisitor;
-        impl Visitor<'_> for IpVisitor {
-            type Value = IpAddr;
-
-            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-                formatter.write_str("an IPv4 address as bytes")
-            }
-
-            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E> 
-            where E: Error {
-                match v.len() {
-                    4 => {
-                        let bytes: [u8; 4] = v.try_into().unwrap();
-                        Ok(IpAddr::from(bytes))
-                    }
-                    16 => {
-                        let bytes: [u8; 16] = v.try_into().unwrap();
-                        Ok(IpAddr::from(bytes))
-                    }
-                    _ => Err(Error::custom("Invalid IP address byte length")),
-                }
-            }
-        }
-
-        deserializer.deserialize_bytes(IpVisitor)
-    }
-}
+pub mod utils;

--- a/tests/schemas/simple_with_override.avsc
+++ b/tests/schemas/simple_with_override.avsc
@@ -1,0 +1,9 @@
+{
+  "type": "record",
+  "name": "test_override",
+  "fields": [
+    {"name": "a", "type": "long", "default": 42},
+    {"name": "b", "type": "string"},
+    {"name": "ip_addr", "type": "bytes"}
+  ]
+}

--- a/tests/schemas/simple_with_override.rs
+++ b/tests/schemas/simple_with_override.rs
@@ -5,7 +5,7 @@ pub struct TestOverride {
     pub a: i64,
     pub b: String,
     /// The IP-address associated with this Avro
-    #[serde(with = "super::ip_addr_serde")]
+    #[serde(with = "super::utils::ip_addr_serde")]
     pub ip_addr: std::net::IpAddr,
 }
 

--- a/tests/schemas/simple_with_override.rs
+++ b/tests/schemas/simple_with_override.rs
@@ -1,0 +1,13 @@
+
+#[derive(Debug, PartialEq, Eq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct TestOverride {
+    #[serde(default = "default_testoverride_a")]
+    pub a: i64,
+    pub b: String,
+    /// The IP-address associated with this Avro
+    #[serde(with = "super::ip_addr_serde")]
+    pub ip_addr: std::net::IpAddr,
+}
+
+#[inline(always)]
+fn default_testoverride_a() -> i64 { 42 }

--- a/tests/schemas/simple_with_override_no_eq.avsc
+++ b/tests/schemas/simple_with_override_no_eq.avsc
@@ -1,0 +1,8 @@
+{
+  "type": "record",
+  "name": "test_override_no_eq",
+  "fields": [
+    {"name": "a", "type": "long", "default": 42},
+    {"name": "b", "type": "string"}
+  ]
+}

--- a/tests/schemas/simple_with_override_no_eq.rs
+++ b/tests/schemas/simple_with_override_no_eq.rs
@@ -1,0 +1,10 @@
+
+#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+pub struct TestOverrideNoEq {
+    #[serde(default = "default_testoverridenoeq_a")]
+    pub a: f64,
+    pub b: String,
+}
+
+#[inline(always)]
+fn default_testoverridenoeq_a() -> f64 { 42.0 }

--- a/tests/schemas/utils/ip_addr_serde.rs
+++ b/tests/schemas/utils/ip_addr_serde.rs
@@ -1,0 +1,39 @@
+//! Serde implementation for `IpAddr` for testing field overrides in `simple_with_override`.
+
+use std::{fmt::Formatter, net::IpAddr};
+use serde::{de::{Error, Visitor}, Deserializer, Serializer};
+
+pub fn serialize<S>(value: &IpAddr, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+    match value {
+        IpAddr::V4(ipv4_addr) => serializer.serialize_bytes(&ipv4_addr.octets()),
+        IpAddr::V6(ipv6_addr) => serializer.serialize_bytes(&ipv6_addr.octets()),
+    }
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<IpAddr, D::Error> where D: Deserializer<'de> {
+    struct IpVisitor;
+    impl Visitor<'_> for IpVisitor {
+        type Value = IpAddr;
+
+        fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+            formatter.write_str("an IPv4 address as bytes")
+        }
+
+        fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+        where E: Error {
+            match v.len() {
+                4 => {
+                    let bytes: [u8; 4] = v.try_into().unwrap();
+                    Ok(IpAddr::from(bytes))
+                }
+                16 => {
+                    let bytes: [u8; 16] = v.try_into().unwrap();
+                    Ok(IpAddr::from(bytes))
+                }
+                _ => Err(Error::custom("Invalid IP address byte length")),
+            }
+        }
+    }
+
+    deserializer.deserialize_bytes(IpVisitor)
+}

--- a/tests/schemas/utils/mod.rs
+++ b/tests/schemas/utils/mod.rs
@@ -1,0 +1,3 @@
+//! Utilities needed for testing generated code.
+
+pub mod ip_addr_serde;


### PR DESCRIPTION
The primary use case for me is using more specific types directly instead of having to create adapter structs, for example having `IpAddr` as a field instead of `Vec<u8>`.

I don't have a direct usecase for changing the docstring, but I imagine it can be useful when you don't control the schema yourself.

I did not implement CLI support as I think it would be very unwieldy to use.