### PR TITLE
fix(cli): ImplementAvroSchema doesn't roundtrip through Display and clap::ValueEnum

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ struct Args {
     pub derive_builders: bool,
 
     /// Implement AvroSchema for generated record structs
-    #[clap(long, value_name = "METHOD", default_value_t = Default::default())]
+    #[clap(long, value_name = "METHOD", default_value_t, value_enum)]
     pub impl_schemas: ImplementAvroSchema,
 
     /// Extract Derives for generated record structs, comma separated, e.g. `std::fmt::Display,std::string::ToString`


### PR DESCRIPTION
Without this fix the CLI will always fail if `--impl-schemas` is not set:
```
error: invalid value 'None' for '--impl-schemas <METHOD>'
  [possible values: derive, copy-build-schema, none]

  tip: a similar value exists: 'none'

For more information, try '--help'.
```

This is because of the following bit from the Clap docs:
- `default_value_t [= <expr>]`: `Arg::default_value` and `Arg::required(false)`
  - Requires `std::fmt::Display` that roundtrips correctly with the `Arg::value_parser` or `#[arg(value_enum)]`
  - Without `<expr>`, relies on `Default::default()`

This bug was introduced by me in #84, sorry for that.