### PR TITLE
feat: Support deserializing based on fully qualified name for Union Variants

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -146,6 +146,9 @@ pub const UNION_TEMPLATE: &str = r#"
 #[serde(remote = "Self")]
 pub enum {{ name }} {
     {%- for s in symbols %}
+    {%- if aliases[s] %}
+    #[serde(alias = "{{ aliases[s] }}")]
+    {%- endif %}
     {{ s }},
     {%- endfor %}
 }
@@ -1087,6 +1090,7 @@ impl Templater {
             let e_name = union_type(union, gen_state, false)?;
 
             let mut symbols = vec![];
+            let mut aliases = HashMap::new();
             let mut visitors = vec![];
             for mut sc in schemas {
                 // Resolve potentially nested schema ref
@@ -1123,22 +1127,43 @@ impl Templater {
                         format!("{u}({u})", u = union_type(union, gen_state, false)?)
                     }
                     Schema::Record(RecordSchema {
-                        name: Name { name, .. },
+                        name: Name { name, namespace },
                         ..
                     }) => {
-                        format!("{rec}({rec})", rec = name.to_upper_camel_case())
+                        let symbol = format!("{rec}({rec})", rec = name.to_upper_camel_case());
+                        if let Some(namespace) = namespace {
+                            let full_name = format!("{}.{}", namespace, name);
+                            if aliases.insert(symbol.clone(), full_name).is_some() {
+                                err!("Names must be unique within a Union: '{}'", name)?
+                            }
+                        }
+                        symbol
                     }
                     Schema::Enum(EnumSchema {
-                        name: Name { name, .. },
+                        name: Name { name, namespace },
                         ..
                     }) => {
-                        format!("{e}({e})", e = sanitize(name.to_upper_camel_case()))
+                        let symbol = format!("{e}({e})", e = sanitize(name.to_upper_camel_case()));
+                        if let Some(namespace) = namespace {
+                            let full_name = format!("{}.{}", namespace, name);
+                            if aliases.insert(symbol.clone(), full_name).is_some() {
+                                err!("Names must be unique within a Union: '{}'", name)?
+                            }
+                        }
+                        symbol
                     }
                     Schema::Fixed(FixedSchema {
-                        name: Name { name, .. },
+                        name: Name { name, namespace },
                         ..
                     }) => {
-                        format!("{f}({f})", f = sanitize(name.to_upper_camel_case()))
+                        let symbol = format!("{f}({f})", f = sanitize(name.to_upper_camel_case()));
+                        if let Some(namespace) = namespace {
+                            let full_name = format!("{}.{}", namespace, name);
+                            if aliases.insert(symbol.clone(), full_name).is_some() {
+                                err!("Names must be unique within a Union: '{}'", name)?
+                            }
+                        }
+                        symbol
                     }
                     Schema::Decimal { .. } => "Decimal(apache_avro::Decimal)".into(),
                     Schema::BigDecimal => "BigDecimal(apache_avro::BigDecimal)".into(),
@@ -1223,6 +1248,7 @@ impl Templater {
             let mut ctx = Context::new();
             ctx.insert("name", &e_name);
             ctx.insert("symbols", &symbols);
+            ctx.insert("aliases", &aliases);
             ctx.insert("visitors", &visitors);
             ctx.insert("use_avro_rs_unions", &self.use_avro_rs_unions);
             ctx.insert("is_eq_derivable", &gen_state.is_eq_derivable(schema));

--- a/tests/invalid.rs
+++ b/tests/invalid.rs
@@ -75,3 +75,33 @@ fn bad_default_for_record() {
     let mut buf = vec![];
     g.generate(&src, &mut buf).map_err(|e| panic!("{e}")).ok();
 }
+
+#[test]
+#[should_panic(expected = r#"Names must be unique within a Union: 'MyRecord'"#)]
+fn duplicate_names_for_union() {
+    let raw_schema = r#"
+[
+  {
+    "type": "record",
+    "name": "MyRecord",
+    "namespace": "com.foo",
+    "fields": [
+      { "name": "foo", "type": "string" }
+    ]
+  },
+  {
+    "type": "record",
+    "name": "MyRecord",
+    "namespace": "com.bar",
+    "fields": [
+      { "name": "bar", "type": "string" }
+    ]
+  }
+]
+"#;
+
+    let g = Generator::new().unwrap();
+    let src = Source::SchemaStr(raw_schema);
+    let mut buf = vec![];
+    g.generate(&src, &mut buf).unwrap();
+}

--- a/tests/schemas/multi_valued_union_records.avsc
+++ b/tests/schemas/multi_valued_union_records.avsc
@@ -10,10 +10,12 @@
     {
       "type": "record",
       "name": "Bar",
+      "namespace": "com.bar",
       "fields": [ {"name": "c", "type": "long"} ]
     }, {
       "type": "record",
       "name": "Baz",
+      "namespace": "com.baz",
       "fields": [ {"name": "d", "type": "float"} ]
     } ]
   } ]

--- a/tests/schemas/multi_valued_union_records.rs
+++ b/tests/schemas/multi_valued_union_records.rs
@@ -13,7 +13,9 @@ pub struct Bar {
 #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(remote = "Self")]
 pub enum UnionBarBaz {
+    #[serde(alias = "com.bar.Bar")]
     Bar(Bar),
+    #[serde(alias = "com.baz.Baz")]
     Baz(Baz),
 }
 


### PR DESCRIPTION
There is another avro deserialization crate [serde_avro_fast](https://github.com/Ten0/serde_avro_fast) that supports schema aware deserialization (apache-avro is working on supporting it https://github.com/apache/avro-rs/pull/237), and it utilizes the fully qualified name to deserialize the identifier for union variants (I'm assuming the reasoning is because of duplicate names from different namespaces being a valid schema). This change adds support for deserializing Union variants using their fully qualified name, while being backwards compatible by using `serde(alias)`

Although `rsgen-avro` is primarily created to work with the `apache-avro` crate, when schema aware deserialization lands, this is probably a feature that may need to be implemented anyways, so IMO its a good future proofing change.

Note that this doesn't actually supports same names from different namespaces, it just supports identifying variants using the fully qualified name during deserialization.

Also made a change to throw an error if unions have the same name, since in the past, it would actually generate successfully code that doesn't compile (two identical variants/symbols in a rust enum).

Although it may not completely address the use case of #79, it could potentially be helpful (And it doesn't create extremely long type names :) ). Please let me know if you have any questions! Thanks!